### PR TITLE
Remove options objects

### DIFF
--- a/wasi-ip-name-lookup.wit
+++ b/wasi-ip-name-lookup.wit
@@ -1,11 +1,6 @@
 use { error, ip-address, ip-address-family } from common-types
 use { network } from wasi-network
 
-record resolve-addresses-options {
-	address-family: option<ip-address-family>,
-	include-unavailable: bool,
-}
-
 /// Resolve an internet host name to a list of IP addresses.
 /// 
 /// See the proposal README.md for a comparison with getaddrinfo.
@@ -34,4 +29,4 @@ record resolve-addresses-options {
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html
 /// - https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
 /// 
-resolve-addresses: async function(name: string, options: resolve-addresses-options) -> expected<list<ip-address>, error>
+resolve-addresses: async function(name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> expected<list<ip-address>, error>

--- a/wasi-socket-udp.wit
+++ b/wasi-socket-udp.wit
@@ -19,13 +19,6 @@ record receive-result {
 	/// ecn: u2, // IP_RECVTOS
 }
 
-record send-options {
-	remote-address: ip-socket-address,
-
-	/// Possible future additions:
-	/// local-address: ip-socket-address, // IP_PKTINFO / IP_SENDSRCADDR / IPV6_PKTINFO
-}
-
 
 /// Create a new UDP socket.
 /// 
@@ -96,7 +89,7 @@ peek: async function(udp-socket: handle socket, iovs: push-buffer<u8>) -> expect
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
 /// - https://man7.org/linux/man-pages/man2/send.2.html
-send: async function(udp-socket: handle socket, iovs: pull-buffer<u8>, options: send-options) -> expected<usize, error>
+send: async function(udp-socket: handle socket, iovs: pull-buffer<u8>, remote-address: ip-socket-address) -> expected<usize, error>
 
 /// Set the destination address.
 /// 


### PR DESCRIPTION
These options objects only existed because I anticipated future additions. However, the parameter lists themselves can most likely also be added to without breaking backwards compatibility.