### PR TITLE
Integrate component-model streams.

### DIFF
--- a/wasi-io-streams.wit
+++ b/wasi-io-streams.wit
@@ -1,7 +1,0 @@
-
-/// Stubs of https://github.com/WebAssembly/wasi-io/
-/// 
-/// TO DISCUSS
-
-resource input-byte-stream {}
-resource output-byte-stream {}

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -104,10 +104,8 @@ remote-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, e
 /// 
 /// The returned sockets are bound and in the Connection state.
 /// 
-/// The returned stream may be closed prematurely by the consumer. In that case the socket becomes available
-/// for accepting again.
+/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an error.
 /// 
-/// Fails when there is already an active `accept` stream operation in progress on the socket.
 /// Fails when this socket is not in the Listening state.
 /// 
 /// References:

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -1,5 +1,4 @@
 use { error, ip-address-family, ip-socket-address, usize } from common-types
-use { input-byte-stream, output-byte-stream } from wasi-io-streams
 use { network } from wasi-network
 use { socket } from wasi-socket
 
@@ -24,11 +23,41 @@ enum shutdown-type {
 /// 
 create-tcp-socket: func(network: handle network, address-family: ip-address-family) -> expected<handle socket, error>
 
-/// TO DISCUSS
-as-input-byte-stream: func(tcp-socket: handle socket) -> handle input-byte-stream
+/// Receive data on the socket.
+/// 
+/// The returned stream can be used to continually read all data from the socket. The stream's final value will be
+/// `Ok(())` when the stream reached end-of-file without errors.
+/// 
+/// The returned stream may be closed prematurely by the consumer. In that case the socket becomes available
+/// for reading again.
+/// 
+/// Fails when there is already an active `receive` operation in progress on the socket.
+/// Fails when the socket is not in the Connection state.
+/// 
+/// References
+/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
+/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
+/// - https://man7.org/linux/man-pages/man2/recv.2.html
+/// - https://man7.org/linux/man-pages/man2/read.2.html
+receive: func(tcp-socket: handle socket) -> stream<u8, expected<unit, error>>
 
-/// TO DISCUSS
-as-output-byte-stream: func(tcp-socket: handle socket) -> handle output-byte-stream
+/// Send data on the socket.
+/// 
+/// The input stream can be used to continually write data to the socket.
+/// After the input stream is finalized by the producer, the socket becomes available for writing again.
+/// 
+/// The returned future completes successfully after the input stream is drained completely.
+/// If an error occurs during sending, the input stream is closed and the future completes with an error.
+/// 
+/// Fails when there is already an active `send` operation in progress on the socket.
+/// Fails when the socket is not in the Connection state.
+/// 
+/// References
+/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html
+/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
+/// - https://man7.org/linux/man-pages/man2/send.2.html
+/// - https://man7.org/linux/man-pages/man2/write.2.html
+send: func(tcp-socket: handle socket, data: stream<u8, unit>) -> future<expected<unit, error>>
 
 /// Bind the socket to a specific IP address and port.
 ///
@@ -77,11 +106,6 @@ listen: async func(tcp-socket: handle socket, backlog-size-hint: option<usize>) 
 
 /// Fails when the socket is not in the Connection state.
 /// 
-/// Read data from the stream just like `InputByteStream::read`, but don't remove the data from the queue.
-peek: async func(tcp-socket: handle socket, iovs: push-buffer<u8>) -> expected<usize, error>
-
-/// Fails when the socket is not in the Connection state.
-/// 
 /// References
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
 /// - https://man7.org/linux/man-pages/man2/getpeername.2.html
@@ -89,8 +113,8 @@ remote-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, e
 
 /// Gracefully shut down the connection.
 /// 
-/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read/receive
-///   operations will return 0, indicating End Of Stream. If there is still data in the receive queue at time of
+/// - receive: the socket is not expecting to receive any more data from the peer. Any active receive stream will be
+///   closed with a success value. If there is still data in the receive queue at time of
 ///   calling `shutdown` or whenever new data arrives afterwards, then (TODO).
 /// - send: the socket is not expecting to send any more data to the peer. After all data in the send queue has
 ///   been sent and acknowledged, a FIN will be sent. All subsequent write/send operations will return an
@@ -113,14 +137,17 @@ remote-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, e
 /// - https://man7.org/linux/man-pages/man2/shutdown.2.html
 shutdown: async func(tcp-socket: handle socket, shutdown-type: shutdown-type) -> expected<unit, error>
 
-/// Unlike POSIX, this function does not returns the remote address.
-/// If you want to know this information, invoke `remote-address` on the newly created socket.
+/// Start accepting new client sockets.
 /// 
+/// The returned sockets are bound and in the Connection state.
+/// 
+/// The returned stream may be closed prematurely by the consumer. In that case the socket becomes available
+/// for accepting again.
+/// 
+/// Fails when there is already an active `accept` stream operation in progress on the socket.
 /// Fails when this socket is not in the Listening state.
-/// 
-/// Returns a new bound socket in the Connection state.
 /// 
 /// References:
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 /// - https://man7.org/linux/man-pages/man2/accept.2.html
-accept: async func(tcp-socket: handle socket) -> expected<handle socket, error>
+accept: func(tcp-socket: handle socket) -> stream<handle socket, expected<unit, error>>

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -2,17 +2,6 @@ use { error, ip-address-family, ip-socket-address, usize } from common-types
 use { network } from wasi-network
 use { socket } from wasi-socket
 
-enum shutdown-type {
-	/// Similar to `SHUT_RD` in POSIX.
-	receive,
-
-	/// Similar to `SHUT_WR` in POSIX.
-	send,
-
-	/// Similar to `SHUT_RDWR` in POSIX.
-	both,
-}
-
 /// Create a new TCP socket.
 /// 
 /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, 0 or IPPROTO_TCP)` in POSIX.
@@ -26,12 +15,11 @@ create-tcp-socket: func(network: handle network, address-family: ip-address-fami
 /// Receive data on the socket.
 /// 
 /// The returned stream can be used to continually read all data from the socket. The stream's final value will be
-/// `Ok(())` when the stream reached end-of-file without errors.
+/// `Ok(())` when the stream reached end-of-file without errors. When the returned stream is closed by the consumer,
+/// a `shutdown(this_socket, SHUT_RD)` syscall is executed.
 /// 
-/// The returned stream may be closed prematurely by the consumer. In that case the socket becomes available
-/// for reading again.
+/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
 /// 
-/// Fails when there is already an active `receive` operation in progress on the socket.
 /// Fails when the socket is not in the Connection state.
 /// 
 /// References
@@ -44,12 +32,13 @@ receive: func(tcp-socket: handle socket) -> stream<u8, expected<unit, error>>
 /// Send data on the socket.
 /// 
 /// The input stream can be used to continually write data to the socket.
-/// After the input stream is finalized by the producer, the socket becomes available for writing again.
+/// After the input stream is finalized by the producer, a `shutdown(this_socket, SHUT_WR)` syscall is executed.
 /// 
 /// The returned future completes successfully after the input stream is drained completely.
 /// If an error occurs during sending, the input stream is closed and the future completes with an error.
 /// 
-/// Fails when there is already an active `send` operation in progress on the socket.
+/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
+/// 
 /// Fails when the socket is not in the Connection state.
 /// 
 /// References
@@ -110,32 +99,6 @@ listen: async func(tcp-socket: handle socket, backlog-size-hint: option<usize>) 
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
 /// - https://man7.org/linux/man-pages/man2/getpeername.2.html
 remote-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, error>
-
-/// Gracefully shut down the connection.
-/// 
-/// - receive: the socket is not expecting to receive any more data from the peer. Any active receive stream will be
-///   closed with a success value. If there is still data in the receive queue at time of
-///   calling `shutdown` or whenever new data arrives afterwards, then (TODO).
-/// - send: the socket is not expecting to send any more data to the peer. After all data in the send queue has
-///   been sent and acknowledged, a FIN will be sent. All subsequent write/send operations will return an
-///   EPIPE error.
-/// - both: receive & send
-/// 
-/// The shutdown function does not close the socket.
-/// 
-/// Fails when the socket is not in the Connection state.
-/// 
-/// TODO: Look into how different platforms behave after shutdown(Read) has been called and new data arrives. According to the internet (unverified):
-/// - BSD: silently discards the data
-/// - Linux: effectively ignores the shutdown call. New data can still be read. If not done will ultimately block the sender.
-/// - Windows: sends RST
-/// 
-/// TODO: Look into how different platforms behave when trying to shut down the same direction multiple times.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html
-/// - https://man7.org/linux/man-pages/man2/shutdown.2.html
-shutdown: async func(tcp-socket: handle socket, shutdown-type: shutdown-type) -> expected<unit, error>
 
 /// Start accepting new client sockets.
 /// 

--- a/wasi-socket-udp.wit
+++ b/wasi-socket-udp.wit
@@ -4,11 +4,8 @@ use { network } from wasi-network
 use { socket } from wasi-socket
 
 
-record receive-result {
-	bytes-received: usize,
-	
-	/// Similar to the `MSG_TRUNC` flag in POSIX.
-	truncated: bool,
+record datagram {
+	data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
 	remote-address: ip-socket-address,
 
 	/// Possible future additions:
@@ -71,25 +68,18 @@ local-address: func(udp-socket: handle socket) -> expected<ip-socket-address, er
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
 /// - https://man7.org/linux/man-pages/man2/recv.2.html
-receive: async func(udp-socket: handle socket, iovs: push-buffer<u8>) -> expected<receive-result, error>
-
-/// receive a message just like `receive`, but don't remove the message from the queue.
-peek: async func(udp-socket: handle socket, iovs: push-buffer<u8>) -> expected<receive-result, error>
+receive: async func(udp-socket: handle socket) -> expected<datagram, error>
 
 /// send a message to a specific destination address.
 /// 
 /// The remote address option is required. To send a message to the "connected" peer,
 /// call `remote-address` to get their address.
 /// 
-/// Returns the number of bytes sent.
-/// 
-/// TODO: Does the returned number of bytes sent ever differ from the supplied buffer size for UDP sockets?
-/// 
 /// References
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
 /// - https://man7.org/linux/man-pages/man2/send.2.html
-send: async func(udp-socket: handle socket, iovs: pull-buffer<u8>, remote-address: ip-socket-address) -> expected<usize, error>
+send: async func(udp-socket: handle socket, datagram: datagram) -> expected<unit, error>
 
 /// Set the destination address.
 /// 


### PR DESCRIPTION
TCP:
- Removed wasi-io-streams stubs
- Removed `peek` method. Don't know how to make it interoperable with streams. Maybe this can emulated in libc?
- Added `receive` & `send`. These can only be called once per socket. Closing the streams automatically calls `shutdown`.
- Removed the manual `shutdown` method.
- Changed `accept` to return a stream of client sockets instead of a single one.
- Potential future idea: merge `listen` & `accept` into a single function that puts the socket in listening mode *and* returns a stream of sockets.

UDP:
- Removed `peek` method for symmetry with TCP.
- Intentionally did not use streams to implement `receive` & `send`. Every `send` call may fail independently from each other, and I haven't figured out a way to signal back errors without ending the entire stream. `receive` could potentially be implemented as a stream, but I haven't for symmetry with `send`.

---

Blocks: https://github.com/bytecodealliance/wasmtime/issues/4276