### PR TITLE
Resource subtyping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Unlike BSD sockets, WASI sockets require capability handles to create sockets an
 The socket APIs have been split up into standalone protocol-specific WASI modules. Both current and future socket modules can then be tailored to the needs of that specific protocol and progress the standardization process independently.
 
 This proposal introduces 4 new WASI modules:
-- [wasi-socket.wit](./wasi-socket.wit)
-- [wasi-socket-tcp.wit](./wasi-socket-tcp.wit)
-- [wasi-socket-udp.wit](./wasi-socket-udp.wit)
 - [wasi-ip-name-lookup.wit](./wasi-ip-name-lookup.wit)
+- [wasi-socket.wit](./wasi-socket.wit)
+  - [wasi-socket-ip.wit](./wasi-socket-ip.wit)
+    - [wasi-socket-tcp.wit](./wasi-socket-tcp.wit)
+    - [wasi-socket-udp.wit](./wasi-socket-udp.wit)
 
 ### Goals
 

--- a/common-types.wit
+++ b/common-types.wit
@@ -35,20 +35,3 @@ variant ip-address {
 	ipv4(ipv4-address),
 	ipv6(ipv6-address),
 }
-
-record ipv4-socket-address {
-	port: u16, // sin_port
-	address: ipv4-address, // sin_addr
-}
-
-record ipv6-socket-address {
-	port: u16, // sin6_port
-	flow-info: u32, // sin6_flowinfo
-	address: ipv6-address, // sin6_addr
-	scope-id: u32, // sin6_scope_id
-}
-
-variant ip-socket-address {
-	ipv4(ipv4-socket-address),
-	ipv6(ipv6-socket-address),
-}

--- a/wasi-socket-ip.wit
+++ b/wasi-socket-ip.wit
@@ -1,0 +1,29 @@
+
+use { error, ipv4-address, ipv6-address, ip-address-family } from common-types
+use { socket } from wasi-socket
+
+record ipv4-socket-address {
+	port: u16, // sin_port
+	address: ipv4-address, // sin_addr
+}
+
+record ipv6-socket-address {
+	port: u16, // sin6_port
+	flow-info: u32, // sin6_flowinfo
+	address: ipv6-address, // sin6_addr
+	scope-id: u32, // sin6_scope_id
+}
+
+variant ip-socket-address {
+	ipv4(ipv4-socket-address),
+	ipv6(ipv6-socket-address),
+}
+
+resource ip-socket implements socket {
+
+	/// Whether this is a IPv4 or IPv6 socket.
+	/// 
+	/// Equivalent to the SO_DOMAIN socket option.
+	address-family: func() -> ip-address-family
+
+}

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -1,114 +1,118 @@
-use { error, ip-address-family, ip-socket-address, usize } from common-types
+use { error, ip-address-family, usize } from common-types
 use { network } from wasi-network
-use { socket } from wasi-socket
+use { ip-socket, ip-socket-address } from wasi-socket-ip
 
-/// Create a new TCP socket.
-/// 
-/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, 0 or IPPROTO_TCP)` in POSIX.
-/// 
-/// References:
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
-/// - https://man7.org/linux/man-pages/man2/socket.2.html
-/// 
-create-tcp-socket: func(network: handle network, address-family: ip-address-family) -> expected<handle socket, error>
+resource tcp-socket implements ip-socket {
 
-/// Receive data on the socket.
-/// 
-/// The returned stream can be used to continually read all data from the socket. The stream's final value will be
-/// `Ok(())` when the stream reached end-of-file without errors. When the returned stream is closed by the consumer,
-/// a `shutdown(this_socket, SHUT_RD)` syscall is executed.
-/// 
-/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
-/// 
-/// Fails when the socket is not in the Connection state.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
-/// - https://man7.org/linux/man-pages/man2/recv.2.html
-/// - https://man7.org/linux/man-pages/man2/read.2.html
-receive: func(tcp-socket: handle socket) -> stream<u8, expected<unit, error>>
+	/// Create a new TCP socket.
+	/// 
+	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, 0 or IPPROTO_TCP)` in POSIX.
+	/// 
+	/// References:
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
+	/// - https://man7.org/linux/man-pages/man2/socket.2.html
+	/// 
+	static new: async func(network: handle network, address-family: ip-address-family) -> expected<handle tcp-socket, error>
 
-/// Send data on the socket.
-/// 
-/// The input stream can be used to continually write data to the socket.
-/// After the input stream is finalized by the producer, a `shutdown(this_socket, SHUT_WR)` syscall is executed.
-/// 
-/// The returned future completes successfully after the input stream is drained completely.
-/// If an error occurs during sending, the input stream is closed and the future completes with an error.
-/// 
-/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
-/// 
-/// Fails when the socket is not in the Connection state.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
-/// - https://man7.org/linux/man-pages/man2/send.2.html
-/// - https://man7.org/linux/man-pages/man2/write.2.html
-send: func(tcp-socket: handle socket, data: stream<u8, unit>) -> future<expected<unit, error>>
+	/// Receive data on the socket.
+	/// 
+	/// The returned stream can be used to continually read all data from the socket. The stream's final value will be
+	/// `Ok(())` when the stream reached end-of-file without errors. When the returned stream is closed by the consumer,
+	/// a `shutdown(this_socket, SHUT_RD)` syscall is executed.
+	/// 
+	/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
+	/// 
+	/// Fails when the socket is not in the Connection state.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
+	/// - https://man7.org/linux/man-pages/man2/recv.2.html
+	/// - https://man7.org/linux/man-pages/man2/read.2.html
+	receive: func() -> stream<u8, expected<unit, error>>
 
-/// Bind the socket to a specific IP address and port.
-///
-/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-/// network interface(s) to bind to.
-/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-/// 
-/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
-/// implicitly bind the socket.
-/// 
-/// Returns an error if the socket is already bound.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
-/// - https://man7.org/linux/man-pages/man2/bind.2.html
-bind: async func(tcp-socket: handle socket, local-address: ip-socket-address) -> expected<unit, error>
+	/// Send data on the socket.
+	/// 
+	/// The input stream can be used to continually write data to the socket.
+	/// After the input stream is finalized by the producer, a `shutdown(this_socket, SHUT_WR)` syscall is executed.
+	/// 
+	/// The returned future completes successfully after the input stream is drained completely.
+	/// If an error occurs during sending, the input stream is closed and the future completes with an error.
+	/// 
+	/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an EPIPE error.
+	/// 
+	/// Fails when the socket is not in the Connection state.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html
+	/// - https://man7.org/linux/man-pages/man2/send.2.html
+	/// - https://man7.org/linux/man-pages/man2/write.2.html
+	send: func(data: stream<u8, unit>) -> future<expected<unit, error>>
 
-/// Get the current bound address.
-/// 
-/// Returns an error if the socket is not bound.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
-/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
-local-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, error>
+	/// Bind the socket to a specific IP address and port.
+	///
+	/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+	/// network interface(s) to bind to.
+	/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+	/// 
+	/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
+	/// implicitly bind the socket.
+	/// 
+	/// Returns an error if the socket is already bound.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
+	/// - https://man7.org/linux/man-pages/man2/bind.2.html
+	bind: async func(local-address: ip-socket-address) -> expected<unit, error>
 
-///	Connect to a remote endpoint.
-/// 
-/// Transitions the socket into the Connection state.
-/// Fails when the socket is already in the Connection or Listener state.
-/// 
-///  References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
-/// - https://man7.org/linux/man-pages/man2/connect.2.html
-connect: async func(tcp-socket: handle socket, remote-address: ip-socket-address) -> expected<unit, error>
+	/// Get the current bound address.
+	/// 
+	/// Returns an error if the socket is not bound.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
+	/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
+	local-address: func() -> expected<ip-socket-address, error>
 
-/// Start listening for new connections.
-/// 
-/// Transitions the socket into the Listener state.
-/// Fails when the socket is already in the Connection or Listener state.
-/// 
-///  References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
-/// - https://man7.org/linux/man-pages/man2/listen.2.html
-listen: async func(tcp-socket: handle socket, backlog-size-hint: option<usize>) -> expected<unit, error>
+	///	Connect to a remote endpoint.
+	/// 
+	/// Transitions the socket into the Connection state.
+	/// Fails when the socket is already in the Connection or Listener state.
+	/// 
+	///  References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
+	/// - https://man7.org/linux/man-pages/man2/connect.2.html
+	connect: async func(remote-address: ip-socket-address) -> expected<unit, error>
 
-/// Fails when the socket is not in the Connection state.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
-/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
-remote-address: func(tcp-socket: handle socket) -> expected<ip-socket-address, error>
+	/// Start listening for new connections.
+	/// 
+	/// Transitions the socket into the Listener state.
+	/// Fails when the socket is already in the Connection or Listener state.
+	/// 
+	///  References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
+	/// - https://man7.org/linux/man-pages/man2/listen.2.html
+	listen: async func(backlog-size-hint: option<usize>) -> expected<unit, error>
 
-/// Start accepting new client sockets.
-/// 
-/// The returned sockets are bound and in the Connection state.
-/// 
-/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an error.
-/// 
-/// Fails when this socket is not in the Listening state.
-/// 
-/// References:
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
-/// - https://man7.org/linux/man-pages/man2/accept.2.html
-accept: func(tcp-socket: handle socket) -> stream<handle socket, expected<unit, error>>
+	/// Fails when the socket is not in the Connection state.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
+	/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
+	remote-address: func() -> expected<ip-socket-address, error>
+
+	/// Start accepting new client sockets.
+	/// 
+	/// The returned sockets are bound and in the Connection state.
+	/// 
+	/// This function can only be called successfully _once_ on a socket. All subsequent calls will result in an error.
+	/// 
+	/// Fails when this socket is not in the Listening state.
+	/// 
+	/// References:
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
+	/// - https://man7.org/linux/man-pages/man2/accept.2.html
+	accept: func() -> stream<handle tcp-socket, expected<unit, error>>
+
+}

--- a/wasi-socket-udp.wit
+++ b/wasi-socket-udp.wit
@@ -1,8 +1,7 @@
 
-use { error, ip-address-family, ip-socket-address, usize } from common-types
+use { error, ip-address-family, usize } from common-types
 use { network } from wasi-network
-use { socket } from wasi-socket
-
+use { ip-socket, ip-socket-address } from wasi-socket-ip
 
 record datagram {
 	data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
@@ -16,95 +15,98 @@ record datagram {
 	/// ecn: u2, // IP_RECVTOS
 }
 
+resource udp-socket implements ip-socket {
 
-/// Create a new UDP socket.
-/// 
-/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, 0 or IPPROTO_UDP)` in POSIX.
-/// 
-/// References:
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
-/// - https://man7.org/linux/man-pages/man2/socket.2.html
-/// 
-create-udp-socket: func(network: handle network, address-family: ip-address-family) -> expected<handle socket, error>
+	/// Create a new UDP socket.
+	/// 
+	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, 0 or IPPROTO_UDP)` in POSIX.
+	/// 
+	/// References:
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
+	/// - https://man7.org/linux/man-pages/man2/socket.2.html
+	/// 
+	static new: async func(network: handle network, address-family: ip-address-family) -> expected<handle udp-socket, error>
 
-/// Bind the socket to a specific IP address and port.
-///
-/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-/// network interface(s) to bind to.
-/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-/// 
-/// When a socket is not explicitly bound, the first invocation to a send or receive operation will
-/// implicitly bind the socket.
-/// 
-/// Returns an error if the socket is already bound.
-/// 
-/// TODO: disallow wildcard binds as long as there isn't a way to pass the local address to send & receive?
-/// - https://blog.cloudflare.com/everything-you-ever-wanted-to-know-about-udp-sockets-but-were-afraid-to-ask-part-1/#sourcing-packets-from-a-wildcard-socket
-/// - https://blog.powerdns.com/2012/10/08/on-binding-datagram-udp-sockets-to-the-any-addresses/
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
-/// - https://man7.org/linux/man-pages/man2/bind.2.html
-bind: async func(udp-socket: handle socket, local-address: ip-socket-address) -> expected<unit, error>
+	/// Bind the socket to a specific IP address and port.
+	///
+	/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+	/// network interface(s) to bind to.
+	/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+	/// 
+	/// When a socket is not explicitly bound, the first invocation to a send or receive operation will
+	/// implicitly bind the socket.
+	/// 
+	/// Returns an error if the socket is already bound.
+	/// 
+	/// TODO: disallow wildcard binds as long as there isn't a way to pass the local address to send & receive?
+	/// - https://blog.cloudflare.com/everything-you-ever-wanted-to-know-about-udp-sockets-but-were-afraid-to-ask-part-1/#sourcing-packets-from-a-wildcard-socket
+	/// - https://blog.powerdns.com/2012/10/08/on-binding-datagram-udp-sockets-to-the-any-addresses/
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
+	/// - https://man7.org/linux/man-pages/man2/bind.2.html
+	bind: async func(local-address: ip-socket-address) -> expected<unit, error>
 
-/// Get the current bound address.
-/// 
-/// Returns an error if the socket is not bound.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
-/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
-local-address: func(udp-socket: handle socket) -> expected<ip-socket-address, error>
+	/// Get the current bound address.
+	/// 
+	/// Returns an error if the socket is not bound.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
+	/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
+	local-address: func() -> expected<ip-socket-address, error>
 
-/// receive a message.
-/// 
-/// Returns:
-/// - The sender address of the datagram
-/// - The number of bytes read.
-/// - When the received datagram is larger than the provided buffers,
-///     the excess data is lost and the `truncated` flag will be set.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
-/// - https://man7.org/linux/man-pages/man2/recv.2.html
-receive: async func(udp-socket: handle socket) -> expected<datagram, error>
+	/// receive a message.
+	/// 
+	/// Returns:
+	/// - The sender address of the datagram
+	/// - The number of bytes read.
+	/// - When the received datagram is larger than the provided buffers,
+	///     the excess data is lost and the `truncated` flag will be set.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
+	/// - https://man7.org/linux/man-pages/man2/recv.2.html
+	receive: async func() -> expected<datagram, error>
 
-/// send a message to a specific destination address.
-/// 
-/// The remote address option is required. To send a message to the "connected" peer,
-/// call `remote-address` to get their address.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
-/// - https://man7.org/linux/man-pages/man2/send.2.html
-send: async func(udp-socket: handle socket, datagram: datagram) -> expected<unit, error>
+	/// send a message to a specific destination address.
+	/// 
+	/// The remote address option is required. To send a message to the "connected" peer,
+	/// call `remote-address` to get their address.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
+	/// - https://man7.org/linux/man-pages/man2/send.2.html
+	send: async func(datagram: datagram) -> expected<unit, error>
 
-/// Set the destination address.
-/// 
-/// When a destination address is set:
-/// - all receive operations will only return datagrams sent from the provided `remote-address`.
-/// - the `send` function can still be used to send to any other destination, however you can't receive their response.
-/// 
-/// Similar to `connect(sock, ...)` in POSIX.
-/// 
-/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
-/// 
-/// TODO: "connect" is a rather odd name for this function because it doesn't reflect what's actually happening.
-///     Feels like it was chosen just to shoehorn UDP into the existing Socket interface.
-///     Do we have to keep this name?
-/// 
-/// TODO: add unconnect ability.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
-/// - https://man7.org/linux/man-pages/man2/connect.2.html
-connect: async func(udp-socket: handle socket, remote-address: ip-socket-address) -> expected<unit, error>
+	/// Set the destination address.
+	/// 
+	/// When a destination address is set:
+	/// - all receive operations will only return datagrams sent from the provided `remote-address`.
+	/// - the `send` function can still be used to send to any other destination, however you can't receive their response.
+	/// 
+	/// Similar to `connect(sock, ...)` in POSIX.
+	/// 
+	/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
+	/// 
+	/// TODO: "connect" is a rather odd name for this function because it doesn't reflect what's actually happening.
+	///     Feels like it was chosen just to shoehorn UDP into the existing Socket interface.
+	///     Do we have to keep this name?
+	/// 
+	/// TODO: add unconnect ability.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
+	/// - https://man7.org/linux/man-pages/man2/connect.2.html
+	connect: async func(remote-address: ip-socket-address) -> expected<unit, error>
 
-/// Get the address set with `connect`.
-/// 
-/// References
-/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
-/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
-remote-address: func(udp-socket: handle socket) -> expected<ip-socket-address, error>
+	/// Get the address set with `connect`.
+	/// 
+	/// References
+	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
+	/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
+	remote-address: func() -> expected<ip-socket-address, error>
+
+}

--- a/wasi-socket.wit
+++ b/wasi-socket.wit
@@ -1,18 +1,4 @@
 
-use { error } from common-types
-
-enum socket-kind {
-	/// TODO: https://github.com/WebAssembly/interface-types/issues/145
-	unknown,
-	tcp,
-	udp,
+resource socket {
+	
 }
-
-resource socket {}
-
-
-/// Get the type of the socket.
-/// 
-/// When this function does not return an error, the argument is guaranteed to be a socket.
-/// Note: `socket-kind::unknown` is not an error.
-kind: func(any-socket: handle socket) -> expected<socket-kind, error>


### PR DESCRIPTION
You might want to hide whitespace changes when viewing the diff.

---

- Made tcp-socket and udp-socket their own type of resource. They both extend a new `ip-socket` resource type, which in turn extends `socket`.
- Removed `socket::kind`, because that can be replaced with runtime type checking.