### PR TITLE
Initial socket options

### DIFF
--- a/wasi-socket-ip.wit
+++ b/wasi-socket-ip.wit
@@ -26,4 +26,16 @@ resource ip-socket implements socket {
 	/// Equivalent to the SO_DOMAIN socket option.
 	address-family: func() -> ip-address-family
 
+	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+	unicast-hop-limit: func() -> expected<u8, error>
+	set-unicast-hop-limit: func(value: u8) -> expected<unit, error>
+
+	/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+	/// Implementations are not required to support dual-stack mode, so calling `set-ipv6-only(false)` might fail.
+	/// 
+	/// Fails when called on an IPv4 socket.
+	/// 
+	/// Equivalent to the IPV6_V6ONLY socket option.
+	ipv6-only: func() -> expected<bool, error>
+	set-ipv6-only: func(value: bool) -> expected<unit, error>
 }

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -115,4 +115,28 @@ resource tcp-socket implements ip-socket {
 	/// - https://man7.org/linux/man-pages/man2/accept.2.html
 	accept: func() -> stream<handle tcp-socket, expected<unit, error>>
 
+	/// Equivalent to the SO_KEEPALIVE socket option.
+	keep-alive: func() -> expected<bool, error>
+	set-keep-alive: func(value: bool) -> expected<unit, error>
+
+	/// Equivalent to the TCP_NODELAY socket option.
+	no-delay: func() -> expected<bool, error>
+	set-no-delay: func(value: bool) -> expected<unit, error>
+
+	/// The kernel buffer space reserved for sends/receives on this socket.
+	/// 
+	/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+	/// 	In other words, after setting a value, reading the same setting back may return a different value.
+	/// 
+	/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+	/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
+	/// 	for internal metadata structures.
+	/// 
+	/// Fails when this socket is in the Listening state.
+	/// 
+	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+	receive-buffer-size: func() -> expected<usize, error>
+	set-receive-buffer-size: func(value: usize) -> expected<unit, error>
+	send-buffer-size: func() -> expected<usize, error>
+	set-send-buffer-size: func(value: usize) -> expected<unit, error>
 }

--- a/wasi-socket-udp.wit
+++ b/wasi-socket-udp.wit
@@ -109,4 +109,20 @@ resource udp-socket implements ip-socket {
 	/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
 	remote-address: func() -> expected<ip-socket-address, error>
 
+	/// The kernel buffer space reserved for sends/receives on this socket.
+	/// 
+	/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+	/// 	In other words, after setting a value, reading the same setting back may return a different value.
+	/// 
+	/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+	/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
+	/// 	for internal metadata structures.
+	/// 
+	/// Fails when this socket is in the Listening state.
+	/// 
+	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+	receive-buffer-size: func() -> expected<usize, error>
+	set-receive-buffer-size: func(value: usize) -> expected<unit, error>
+	send-buffer-size: func() -> expected<usize, error>
+	set-send-buffer-size: func(value: usize) -> expected<unit, error>
 }


### PR DESCRIPTION
Add methods for socket options:
- IP_TTL/IPV6_UNICAST_HOPS,
- IPV6_V6ONLY,
- SO_KEEPALIVE,
- TCP_NODELAY,
- SO_RCVBUF,
- SO_SNDBUF.
