### PR TITLE
Replace `async` with `future`s

### DIFF
--- a/wasi-ip-name-lookup.wit
+++ b/wasi-ip-name-lookup.wit
@@ -29,4 +29,4 @@ use { network } from wasi-network
 /// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html
 /// - https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
 /// 
-resolve-addresses: async func(name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> expected<list<ip-address>, error>
+resolve-addresses: func(name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> future<expected<list<ip-address>, error>>

--- a/wasi-socket-tcp.wit
+++ b/wasi-socket-tcp.wit
@@ -12,7 +12,7 @@ resource tcp-socket implements ip-socket {
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 	/// - https://man7.org/linux/man-pages/man2/socket.2.html
 	/// 
-	static new: async func(network: handle network, address-family: ip-address-family) -> expected<handle tcp-socket, error>
+	static new: func(network: handle network, address-family: ip-address-family) -> future<expected<handle tcp-socket, error>>
 
 	/// Receive data on the socket.
 	/// 
@@ -64,7 +64,7 @@ resource tcp-socket implements ip-socket {
 	/// References
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 	/// - https://man7.org/linux/man-pages/man2/bind.2.html
-	bind: async func(local-address: ip-socket-address) -> expected<unit, error>
+	bind: func(local-address: ip-socket-address) -> future<expected<unit, error>>
 
 	/// Get the current bound address.
 	/// 
@@ -83,7 +83,7 @@ resource tcp-socket implements ip-socket {
 	///  References
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 	/// - https://man7.org/linux/man-pages/man2/connect.2.html
-	connect: async func(remote-address: ip-socket-address) -> expected<unit, error>
+	connect: func(remote-address: ip-socket-address) -> future<expected<unit, error>>
 
 	/// Start listening for new connections.
 	/// 
@@ -93,7 +93,7 @@ resource tcp-socket implements ip-socket {
 	///  References
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
 	/// - https://man7.org/linux/man-pages/man2/listen.2.html
-	listen: async func(backlog-size-hint: option<usize>) -> expected<unit, error>
+	listen: func(backlog-size-hint: option<usize>) -> future<expected<unit, error>>
 
 	/// Fails when the socket is not in the Connection state.
 	/// 

--- a/wasi-socket-udp.wit
+++ b/wasi-socket-udp.wit
@@ -25,7 +25,7 @@ resource udp-socket implements ip-socket {
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 	/// - https://man7.org/linux/man-pages/man2/socket.2.html
 	/// 
-	static new: async func(network: handle network, address-family: ip-address-family) -> expected<handle udp-socket, error>
+	static new: func(network: handle network, address-family: ip-address-family) -> future<expected<handle udp-socket, error>>
 
 	/// Bind the socket to a specific IP address and port.
 	///
@@ -45,7 +45,7 @@ resource udp-socket implements ip-socket {
 	/// References
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 	/// - https://man7.org/linux/man-pages/man2/bind.2.html
-	bind: async func(local-address: ip-socket-address) -> expected<unit, error>
+	bind: func(local-address: ip-socket-address) -> future<expected<unit, error>>
 
 	/// Get the current bound address.
 	/// 
@@ -68,7 +68,7 @@ resource udp-socket implements ip-socket {
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
 	/// - https://man7.org/linux/man-pages/man2/recv.2.html
-	receive: async func() -> expected<datagram, error>
+	receive: func() -> future<expected<datagram, error>>
 
 	/// send a message to a specific destination address.
 	/// 
@@ -79,7 +79,7 @@ resource udp-socket implements ip-socket {
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
 	/// - https://man7.org/linux/man-pages/man2/send.2.html
-	send: async func(datagram: datagram) -> expected<unit, error>
+	send: func(datagram: datagram) -> future<expected<unit, error>>
 
 	/// Set the destination address.
 	/// 
@@ -100,7 +100,7 @@ resource udp-socket implements ip-socket {
 	/// References
 	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 	/// - https://man7.org/linux/man-pages/man2/connect.2.html
-	connect: async func(remote-address: ip-socket-address) -> expected<unit, error>
+	connect: func(remote-address: ip-socket-address) -> future<expected<unit, error>>
 
 	/// Get the address set with `connect`.
 	/// 


### PR DESCRIPTION
[The `async` keyword has been removed.](https://github.com/WebAssembly/component-model/pull/98)