### PR TITLE
Enclose URLs in angle brackets

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -200,8 +200,8 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</li>
-<li>https://man7.org/linux/man-pages/man2/bind.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/bind.2.html">https://man7.org/linux/man-pages/man2/bind.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -228,8 +228,8 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html</li>
-<li>https://man7.org/linux/man-pages/man2/connect.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/connect.2.html">https://man7.org/linux/man-pages/man2/connect.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -254,9 +254,9 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html</li>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html</li>
-<li>https://man7.org/linux/man-pages/man2/recv.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/recv.2.html">https://man7.org/linux/man-pages/man2/recv.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -277,9 +277,9 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html</li>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html</li>
-<li>https://man7.org/linux/man-pages/man2/send.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html</a></li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/send.2.html">https://man7.org/linux/man-pages/man2/send.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -295,8 +295,8 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <p>Returns an error if the socket is not bound.</p>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html</li>
-<li>https://man7.org/linux/man-pages/man2/getsockname.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/getsockname.2.html">https://man7.org/linux/man-pages/man2/getsockname.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -310,8 +310,8 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <p>Get the address set with <a href="#connect"><code>connect</code></a>.</p>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html</li>
-<li>https://man7.org/linux/man-pages/man2/getpeername.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/getpeername.2.html">https://man7.org/linux/man-pages/man2/getpeername.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -490,8 +490,8 @@ at time of creation, the socket is not bound to any <a href="#network"><code>net
 the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>
 <p>References:</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html</li>
-<li>https://man7.org/linux/man-pages/man2/socket.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/socket.2.html">https://man7.org/linux/man-pages/man2/socket.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -745,8 +745,8 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</li>
-<li>https://man7.org/linux/man-pages/man2/bind.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/bind.2.html">https://man7.org/linux/man-pages/man2/bind.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -774,8 +774,8 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html</li>
-<li>https://man7.org/linux/man-pages/man2/connect.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/connect.2.html">https://man7.org/linux/man-pages/man2/connect.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -798,8 +798,8 @@ implicitly bind the socket.</p>
 </ul>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html</li>
-<li>https://man7.org/linux/man-pages/man2/listen.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/listen.2.html">https://man7.org/linux/man-pages/man2/listen.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -818,8 +818,8 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <p>Fails when this socket is not in the Listening state.</p>
 <p>References:</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html</li>
-<li>https://man7.org/linux/man-pages/man2/accept.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/accept.2.html">https://man7.org/linux/man-pages/man2/accept.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -834,8 +834,8 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <p>Returns an error if the socket is not bound.</p>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html</li>
-<li>https://man7.org/linux/man-pages/man2/getsockname.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/getsockname.2.html">https://man7.org/linux/man-pages/man2/getsockname.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -850,8 +850,8 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <p>Fails when the socket is not in the Connection state.</p>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html</li>
-<li>https://man7.org/linux/man-pages/man2/getpeername.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/getpeername.2.html">https://man7.org/linux/man-pages/man2/getpeername.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1063,8 +1063,8 @@ operations on the <a href="#output_stream"><code>output-stream</code></a> associ
 <p>Fails when the socket is not in the Connection state.</p>
 <p>References</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html</li>
-<li>https://man7.org/linux/man-pages/man2/shutdown.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/shutdown.2.html">https://man7.org/linux/man-pages/man2/shutdown.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1107,8 +1107,8 @@ at time of creation, the socket is not bound to any <a href="#network"><code>net
 is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>
 <p>References:</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html</li>
-<li>https://man7.org/linux/man-pages/man2/socket.2.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man2/socket.2.html">https://man7.org/linux/man-pages/man2/socket.2.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1165,8 +1165,8 @@ Or it immediately fails whenever <code>name</code> is:</p>
 </ul>
 <p>References:</p>
 <ul>
-<li>https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html</li>
-<li>https://man7.org/linux/man-pages/man3/getaddrinfo.3.html</li>
+<li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html</a></li>
+<li><a href="https://man7.org/linux/man-pages/man3/getaddrinfo.3.html">https://man7.org/linux/man-pages/man3/getaddrinfo.3.html</a></li>
 </ul>
 <h5>Params</h5>
 <ul>

--- a/wit/ip-name-lookup.wit
+++ b/wit/ip-name-lookup.wit
@@ -26,8 +26,8 @@ default interface ip-name-lookup {
 	/// - a syntactically invalid domain name in another way
 	/// 
 	/// References:
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html
-	/// - https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
 	/// 
 	resolve-addresses: func(network: network, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error>
 

--- a/wit/tcp-create-socket.wit
+++ b/wit/tcp-create-socket.wit
@@ -12,8 +12,8 @@ default interface tcp-create-socket {
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
 	/// References:
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
-	/// - https://man7.org/linux/man-pages/man2/socket.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// 
 	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error>
 }

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -33,8 +33,8 @@ default interface tcp {
 	/// - the socket is already bound.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
-	/// - https://man7.org/linux/man-pages/man2/bind.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
 
 	/// Connect to a remote endpoint.
@@ -50,8 +50,8 @@ default interface tcp {
 	/// - either the remote IP address or port is 0.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
-	/// - https://man7.org/linux/man-pages/man2/connect.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<tuple<input-stream, output-stream>, error>
 
 	/// Start listening for new connections.
@@ -64,8 +64,8 @@ default interface tcp {
 	/// - the socket is already in the Connection or Listener state.
 	///
 	///  References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
-	/// - https://man7.org/linux/man-pages/man2/listen.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 	listen: func(this: tcp-socket, network: network) -> result<_, error>
 
 	/// Accept a new client socket.
@@ -78,8 +78,8 @@ default interface tcp {
 	/// Fails when this socket is not in the Listening state.
 	/// 
 	/// References:
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
-	/// - https://man7.org/linux/man-pages/man2/accept.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+	/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 	accept: func(this: tcp-socket) -> result<tuple<tcp-socket, input-stream, output-stream>, error>
 
 	/// Get the bound local address.
@@ -87,8 +87,8 @@ default interface tcp {
 	/// Returns an error if the socket is not bound.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
-	/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 	local-address: func(this: tcp-socket) -> result<ip-socket-address, error>
 
 	/// Get the bound remote address.
@@ -96,8 +96,8 @@ default interface tcp {
 	/// Fails when the socket is not in the Connection state.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
-	/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error>
 
 	/// Whether this is a IPv4 or IPv6 socket.
@@ -177,8 +177,8 @@ default interface tcp {
 	/// Fails when the socket is not in the Connection state.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html
-	/// - https://man7.org/linux/man-pages/man2/shutdown.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+	/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
 	shutdown: func(this: tcp-socket, shutdown-type: shutdown-type) -> result<_, error>
 
 	/// Dispose of the specified `tcp-socket`, after which it may no longer be used.

--- a/wit/udp-create-socket.wit
+++ b/wit/udp-create-socket.wit
@@ -12,8 +12,8 @@ default interface udp-create-socket {
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
 	/// References:
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
-	/// - https://man7.org/linux/man-pages/man2/socket.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// 
 	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error>
 }

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -35,8 +35,8 @@ default interface udp {
 	/// - the socket is already bound.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
-	/// - https://man7.org/linux/man-pages/man2/bind.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error>
 
 	/// Set the destination address.
@@ -53,8 +53,8 @@ default interface udp {
 	/// - the socket is already bound to a different network.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
-	/// - https://man7.org/linux/man-pages/man2/connect.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error>
 
 	/// Receive a message.
@@ -67,9 +67,9 @@ default interface udp {
 	/// - the socket is not bound.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
-	/// - https://man7.org/linux/man-pages/man2/recv.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+	/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
 	receive: func(this: udp-socket) -> result<datagram, error>
 
 	/// Send a message to a specific destination address.
@@ -82,9 +82,9 @@ default interface udp {
 	/// - the socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
-	/// - https://man7.org/linux/man-pages/man2/send.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+	/// - <https://man7.org/linux/man-pages/man2/send.2.html>
 	send: func(this: udp-socket, datagram: datagram) -> result<_, error>
 
 	/// Get the current bound address.
@@ -92,15 +92,15 @@ default interface udp {
 	/// Returns an error if the socket is not bound.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
-	/// - https://man7.org/linux/man-pages/man2/getsockname.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+	/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 	local-address: func(this: udp-socket) -> result<ip-socket-address, error>
 
 	/// Get the address set with `connect`.
 	/// 
 	/// References
-	/// - https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
-	/// - https://man7.org/linux/man-pages/man2/getpeername.2.html
+	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+	/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 	remote-address: func(this: udp-socket) -> result<ip-socket-address, error>
 
 	/// Whether this is a IPv4 or IPv6 socket.


### PR DESCRIPTION
To ensure that markdown renderers properly handle bare URLs, enclose them them in [angle brackets].

[angle brackets]: https://www.markdownguide.org/basic-syntax/#urls-and-email-addresses