### PR TITLE
Rename `default-network` to `instance-network`.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -3,7 +3,7 @@
 <li>Imports:
 <ul>
 <li>interface <a href="#network"><code>network</code></a></li>
-<li>interface <a href="#default_network"><code>default-network</code></a></li>
+<li>interface <a href="#instance_network"><code>instance-network</code></a></li>
 <li>interface <a href="#poll"><code>poll</code></a></li>
 <li>interface <a href="#udp"><code>udp</code></a></li>
 <li>interface <a href="#udp_create_socket"><code>udp-create-socket</code></a></li>
@@ -96,7 +96,7 @@ There is no need for this to map 1:1 to a physical network interface.
 <ul>
 <li><a name="drop_network.this"><code>this</code></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
 </ul>
-<h2><a name="default_network">Import interface default-network</a></h2>
+<h2><a name="instance_network">Import interface instance-network</a></h2>
 <p>This interface provides a value-export of the default network handle..</p>
 <hr />
 <h3>Types</h3>
@@ -105,11 +105,11 @@ There is no need for this to map 1:1 to a physical network interface.
 <p>
 ----
 <h3>Functions</h3>
-<h4><a name="default_network"><code>default-network: func</code></a></h4>
+<h4><a name="instance_network"><code>instance-network: func</code></a></h4>
 <p>Get a handle to the default network.</p>
 <h5>Return values</h5>
 <ul>
-<li><a name="default_network.0"></a> <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="instance_network.0"></a> <a href="#network"><a href="#network"><code>network</code></a></a></li>
 </ul>
 <h2><a name="poll">Import interface poll</a></h2>
 <p>A poll API intended to let users wait for I/O events on multiple handles

--- a/wit/instance-network.wit
+++ b/wit/instance-network.wit
@@ -1,9 +1,9 @@
 
 /// This interface provides a value-export of the default network handle..
-default interface default-network {
+default interface instance-network {
 	use pkg.network.{network}
 
 	/// Get a handle to the default network.
-	default-network: func() -> network
+	instance-network: func() -> network
 
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,6 +1,6 @@
 
 default world example-world {
-    import default-network: pkg.default-network
+    import instance-network: pkg.instance-network
     import network: pkg.network
     import udp: pkg.udp
     import udp-create-socket: pkg.udp-create-socket


### PR DESCRIPTION
Rename `default-network` to `instance-network`. This follows the convention now being used in [wasi-clocks], which is following the theory that "instance" better conveys that this resembles what will be per-instance value imports in the future.

[wasi-clocks]: https://github.com/WebAssembly/wasi-clocks/blob/main/wit/instance-monotonic-clock.wit