### PR TITLE
Define async functions

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -123,6 +123,18 @@ combined with a couple of errors that are always possible:</p>
 <p>This operation is incompatible with another asynchronous operation that is already in progress.
 </li>
 <li>
+<p><a name="error_code.not_in_progress"><code>not-in-progress</code></a></p>
+<p>Trying to finish an asynchronous operation that:
+- has not been started yet, or:
+- was already finished by a previous `finish-*` call.
+<p>Note: this is scheduled to be removed when <code>future</code>s are natively supported.</p>
+</li>
+<li>
+<p><a name="error_code.would_block"><code>would-block</code></a></p>
+<p>The operation has been aborted because it could not be completed immediately.
+<p>Note: this is scheduled to be removed when <code>future</code>s are natively supported.</p>
+</li>
+<li>
 <p><a name="error_code.address_family_not_supported"><code>address-family-not-supported</code></a></p>
 <p>The specified address-family is not supported.
 </li>
@@ -318,20 +330,26 @@ mean &quot;ready&quot;.</p>
 </ul>
 <hr />
 <h3>Functions</h3>
-<h4><a name="bind"><code>bind: func</code></a></h4>
+<h4><a name="start_bind"><code>start-bind: func</code></a></h4>
 <p>Bind the socket to a specific network on the provided IP address and port.</p>
 <p>If the IP address is zero (<code>0.0.0.0</code> in IPv4, <code>::</code> in IPv6), it is left to the implementation to decide which
 network interface(s) to bind to.
 If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <p>When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.</p>
-<h1>Typical errors</h1>
+<p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
+<h1>Typical <code>start</code> errors</h1>
 <ul>
 <li><code>address-family-mismatch</code>:   The <a href="#local_address"><code>local-address</code></a> has the wrong address family. (EINVAL)</li>
 <li><code>already-bound</code>:             The socket is already bound. (EINVAL)</li>
+<li><code>concurrency-conflict</code>:      Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h1>Typical <code>finish</code> errors</h1>
+<ul>
 <li><code>ephemeral-ports-exhausted</code>: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)</li>
 <li><code>address-in-use</code>:            Address is already in use. (EADDRINUSE)</li>
 <li><code>address-not-bindable</code>:      <a href="#local_address"><code>local-address</code></a> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
-<li><code>concurrency-conflict</code>:      Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>not-in-progress</code>:           A <code>bind</code> operation is not in progress.</li>
+<li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -342,15 +360,24 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="bind.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="start_bind.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="start_bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="start_bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="connect"><code>connect: func</code></a></h4>
+<h4><a name="finish_bind"><code>finish-bind: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="finish_bind.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="start_connect"><code>start-connect: func</code></a></h4>
 <p>Set the destination address.</p>
 <p>The local-address is updated based on the best network path to <a href="#remote_address"><code>remote-address</code></a>.</p>
 <p>When a destination address is set:</p>
@@ -359,14 +386,20 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <li>the <a href="#send"><code>send</code></a> function can only be used to send to this destination.</li>
 </ul>
 <p>Note that this function does not generate any network traffic and the peer is not aware of this &quot;connection&quot;.</p>
-<h1>Typical errors</h1>
+<p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
+<h1>Typical <code>start</code> errors</h1>
 <ul>
 <li><code>address-family-mismatch</code>:   The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
 <li><code>invalid-remote-address</code>:    The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-remote-address</code>:    The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>already-attached</code>:          The socket is already bound to a different network. The <a href="#network"><code>network</code></a> passed to <a href="#connect"><code>connect</code></a> must be identical to the one passed to <a href="#bind"><code>bind</code></a>.</li>
+<li><code>already-attached</code>:          The socket is already bound to a different network. The <a href="#network"><code>network</code></a> passed to <code>connect</code> must be identical to the one passed to <code>bind</code>.</li>
+<li><code>concurrency-conflict</code>:      Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h1>Typical <code>finish</code> errors</h1>
+<ul>
 <li><code>ephemeral-ports-exhausted</code>: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)</li>
-<li><code>concurrency-conflict</code>:      Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>not-in-progress</code>:           A <code>connect</code> operation is not in progress.</li>
+<li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -377,13 +410,22 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="connect.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="start_connect.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="start_connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="start_connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="finish_connect"><code>finish-connect: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="finish_connect.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="finish_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="receive"><code>receive: func</code></a></h4>
 <p>Receive a message.</p>
@@ -396,6 +438,7 @@ If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <ul>
 <li><code>not-bound</code>:          The socket is not bound to any local address. (EINVAL)</li>
 <li><code>remote-unreachable</code>: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
+<li><code>would-block</code>:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -424,10 +467,11 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <li><code>address-family-mismatch</code>: The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
 <li><code>invalid-remote-address</code>:  The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-remote-address</code>:  The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and the <code>datagram.remote-address</code> does not match the address passed to <a href="#connect"><code>connect</code></a>. (EISCONN)</li>
+<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and the <code>datagram.remote-address</code> does not match the address passed to <code>connect</code>. (EISCONN)</li>
 <li><code>not-bound</code>:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.</li>
 <li><code>remote-unreachable</code>:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
 <li><code>datagram-too-large</code>:      The datagram is too large. (EMSGSIZE)</li>
+<li><code>would-block</code>:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -470,7 +514,7 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <li><a name="local_address.0"></a> result&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="remote_address"><code>remote-address: func</code></a></h4>
-<p>Get the address set with <a href="#connect"><code>connect</code></a>.</p>
+<p>Get the address set with <code>connect</code>.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-connected</code>: The socket is not connected to a remote address. (ENOTCONN)</li>
@@ -509,7 +553,7 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <li><code>ipv6-only-operation</code>:  (get/set) <code>this</code> socket is an IPv4 socket.</li>
 <li><code>already-bound</code>:        (set) The socket is already bound.</li>
 <li><code>not-supported</code>:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)</li>
-<li><code>concurrency-conflict</code>: (set) Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -533,7 +577,7 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <p>Equivalent to the IP_TTL &amp; IPV6_UNICAST_HOPS socket options.</p>
 <h1>Typical errors</h1>
 <ul>
-<li><code>concurrency-conflict</code>: (set) Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -564,7 +608,7 @@ for internal metadata structures.</p>
 <p>Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.</p>
 <h1>Typical errors</h1>
 <ul>
-<li><code>concurrency-conflict</code>: (set) Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) Another <code>bind</code> or <code>connect</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -602,35 +646,6 @@ for internal metadata structures.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="non_blocking"><code>non-blocking: func</code></a></h4>
-<p>Get/set the blocking mode of the socket.</p>
-<p>By default a socket is in &quot;blocking&quot; mode, meaning that any function blocks and waits for its completion.
-When switched to &quot;non-blocking&quot; mode, operations that would block return an <code>would-block</code> error. After which
-the API consumer is expected to call <a href="#subscribe"><code>subscribe</code></a> and wait for completion using the wasi-poll module.</p>
-<p>Note: these functions are here for WASI Preview2 only.
-They're planned to be removed when <code>future</code> is natively supported in Preview3.</p>
-<h1>Typical errors</h1>
-<ul>
-<li><code>concurrency-conflict</code>: (set) Another <a href="#bind"><code>bind</code></a> or <a href="#connect"><code>connect</code></a> operation is already in progress. (EALREADY)</li>
-</ul>
-<h5>Params</h5>
-<ul>
-<li><a name="non_blocking.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="non_blocking.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="set_non_blocking"><code>set-non-blocking: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="set_non_blocking.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
-<li><a name="set_non_blocking.value"><code>value</code></a>: <code>bool</code></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="set_non_blocking.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="subscribe"><code>subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the socket is ready for I/O.</p>
@@ -672,8 +687,9 @@ It's planned to be removed when <code>future</code> is natively supported in Pre
 <p>Create a new UDP socket.</p>
 <p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)</code> in POSIX.</p>
 <p>This function does not require a network capability handle. This is considered to be safe because
-at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <a href="#bind"><code>bind</code></a>/<a href="#connect"><code>connect</code></a> is called,
+at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <code>bind</code>/<code>connect</code> is called,
 the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>
+<p>All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-supported</code>:                The host does not support UDP sockets. (EOPNOTSUPP)</li>
@@ -926,21 +942,27 @@ be used.</p>
 </ul>
 <hr />
 <h3>Functions</h3>
-<h4><a name="bind"><code>bind: func</code></a></h4>
+<h4><a name="start_bind"><code>start-bind: func</code></a></h4>
 <p>Bind the socket to a specific network on the provided IP address and port.</p>
 <p>If the IP address is zero (<code>0.0.0.0</code> in IPv4, <code>::</code> in IPv6), it is left to the implementation to decide which
 network interface(s) to bind to.
 If the TCP/UDP port is zero, the socket will be bound to a random free port.</p>
 <p>When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 implicitly bind the socket.</p>
-<h1>Typical errors</h1>
+<p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
+<h1>Typical <code>start</code> errors</h1>
 <ul>
 <li><code>address-family-mismatch</code>:   The <a href="#local_address"><code>local-address</code></a> has the wrong address family. (EINVAL)</li>
 <li><code>already-bound</code>:             The socket is already bound. (EINVAL)</li>
+<li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h1>Typical <code>finish</code> errors</h1>
+<ul>
 <li><code>ephemeral-ports-exhausted</code>: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)</li>
 <li><code>address-in-use</code>:            Address is already in use. (EADDRINUSE)</li>
 <li><code>address-not-bindable</code>:      <a href="#local_address"><code>local-address</code></a> is not an address that the <a href="#network"><code>network</code></a> can bind to. (EADDRNOTAVAIL)</li>
-<li><code>concurrency-conflict</code>:      Another <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>not-in-progress</code>:           A <code>bind</code> operation is not in progress.</li>
+<li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -951,35 +973,49 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="bind.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="start_bind.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="start_bind.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="start_bind.local_address"><a href="#local_address"><code>local-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="start_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="connect"><code>connect: func</code></a></h4>
+<h4><a name="finish_bind"><code>finish-bind: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="finish_bind.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="finish_bind.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="start_connect"><code>start-connect: func</code></a></h4>
 <p>Connect to a remote endpoint.</p>
 <p>On success:</p>
 <ul>
 <li>the socket is transitioned into the Connection state</li>
 <li>a pair of streams is returned that can be used to read &amp; write to the connection</li>
 </ul>
-<h1>Typical errors</h1>
+<h1>Typical <code>start</code> errors</h1>
+<ul>
+<li><code>address-family-mismatch</code>:   The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
+<li><code>invalid-remote-address</code>:    The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EADDRNOTAVAIL on Windows)</li>
+<li><code>invalid-remote-address</code>:    The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EADDRNOTAVAIL on Windows)</li>
+<li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <code>connect</code> must be identical to the one passed to <code>bind</code>.</li>
+<li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN)</li>
+<li><code>already-listening</code>:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)</li>
+<li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h1>Typical <code>finish</code> errors</h1>
 <ul>
 <li><code>timeout</code>:                   Connection timed out. (ETIMEDOUT)</li>
 <li><code>connection-refused</code>:        The connection was forcefully rejected. (ECONNREFUSED)</li>
 <li><code>connection-reset</code>:          The connection was reset. (ECONNRESET)</li>
 <li><code>remote-unreachable</code>:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
-<li><code>address-family-mismatch</code>:   The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-remote-address</code>:    The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EADDRNOTAVAIL on Windows)</li>
-<li><code>invalid-remote-address</code>:    The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EADDRNOTAVAIL on Windows)</li>
-<li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <a href="#connect"><code>connect</code></a> must be identical to the one passed to <a href="#bind"><code>bind</code></a>.</li>
-<li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN)</li>
-<li><code>already-listening</code>:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)</li>
 <li><code>ephemeral-ports-exhausted</code>: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)</li>
-<li><code>concurrency-conflict</code>:      Another <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>not-in-progress</code>:           A <code>connect</code> operation is not in progress.</li>
+<li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -990,24 +1026,39 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="connect.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
-<li><a name="connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="start_connect.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="start_connect.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="start_connect.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="connect.0"></a> result&lt;(<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="start_connect.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="listen"><code>listen: func</code></a></h4>
+<h4><a name="finish_connect"><code>finish-connect: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="finish_connect.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="finish_connect.0"></a> result&lt;(<a href="#input_stream"><a href="#input_stream"><code>input-stream</code></a></a>, <a href="#output_stream"><a href="#output_stream"><code>output-stream</code></a></a>), <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="start_listen"><code>start-listen: func</code></a></h4>
 <p>Start listening for new connections.</p>
 <p>Transitions the socket into the Listener state.</p>
-<h1>Typical errors</h1>
+<p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
+<h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <a href="#listen"><code>listen</code></a> must be identical to the one passed to <a href="#bind"><code>bind</code></a>.</li>
+<li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <code>listen</code> must be identical to the one passed to <code>bind</code>.</li>
 <li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)</li>
 <li><code>already-listening</code>:         The socket is already in the Listener state.</li>
+<li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EINVAL on BSD)</li>
+</ul>
+<h1>Typical <code>finish</code> errors</h1>
+<ul>
 <li><code>ephemeral-ports-exhausted</code>: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)</li>
-<li><code>concurrency-conflict</code>:      Another <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EINVAL on BSD)</li>
+<li><code>not-in-progress</code>:           A <code>listen</code> operation is not in progress.</li>
+<li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h1>References</h1>
 <ul>
@@ -1018,12 +1069,21 @@ implicitly bind the socket.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="listen.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
+<li><a name="start_listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="start_listen.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="start_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="finish_listen"><code>finish-listen: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="finish_listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="finish_listen.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="accept"><code>accept: func</code></a></h4>
 <p>Accept a new client socket.</p>
@@ -1033,6 +1093,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-listening</code>: Socket is not in the Listener state. (EINVAL)</li>
+<li><code>would-block</code>:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <p>Host implementations must skip over transient errors returned by the native accept syscall.</p>
 <h1>References</h1>
@@ -1111,7 +1172,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <li><code>ipv6-only-operation</code>:  (get/set) <code>this</code> socket is an IPv4 socket.</li>
 <li><code>already-bound</code>:        (set) The socket is already bound.</li>
 <li><code>not-supported</code>:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)</li>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1136,7 +1197,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>already-connected</code>:    (set) The socket is already in the Connection state.</li>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1151,7 +1212,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <p>Equivalent to the SO_KEEPALIVE socket option.</p>
 <h1>Typical errors</h1>
 <ul>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1175,7 +1236,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <p>Equivalent to the TCP_NODELAY socket option.</p>
 <h1>Typical errors</h1>
 <ul>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1201,7 +1262,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <ul>
 <li><code>already-connected</code>:    (set) The socket is already in the Connection state.</li>
 <li><code>already-listening</code>:    (set) The socket is already in the Listener state.</li>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1233,7 +1294,7 @@ for internal metadata structures.</p>
 <ul>
 <li><code>already-connected</code>:    (set) The socket is already in the Connection state.</li>
 <li><code>already-listening</code>:    (set) The socket is already in the Listener state.</li>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1272,35 +1333,6 @@ for internal metadata structures.</p>
 <ul>
 <li><a name="set_send_buffer_size.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="non_blocking"><code>non-blocking: func</code></a></h4>
-<p>Get/set the blocking mode of the socket.</p>
-<p>By default a socket is in &quot;blocking&quot; mode, meaning that any function blocks and waits for its completion.
-When switched to &quot;non-blocking&quot; mode, operations that would block return an <code>would-block</code> error. After which
-the API consumer is expected to call <a href="#subscribe"><code>subscribe</code></a> and wait for completion using the wasi-poll module.</p>
-<p>Note: these functions are here for WASI Preview2 only.
-They're planned to be removed when <code>future</code> is natively supported in Preview3.</p>
-<h1>Typical errors</h1>
-<ul>
-<li><code>concurrency-conflict</code>: (set) A <a href="#bind"><code>bind</code></a>, <a href="#connect"><code>connect</code></a> or <a href="#listen"><code>listen</code></a> operation is already in progress. (EALREADY)</li>
-</ul>
-<h5>Params</h5>
-<ul>
-<li><a name="non_blocking.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="non_blocking.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="set_non_blocking"><code>set-non-blocking: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="set_non_blocking.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_non_blocking.value"><code>value</code></a>: <code>bool</code></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="set_non_blocking.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
 <h4><a name="subscribe"><code>subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the socket is ready for I/O.</p>
 <p>Note: this function is here for WASI Preview2 only.
@@ -1314,7 +1346,7 @@ It's planned to be removed when <code>future</code> is natively supported in Pre
 <li><a name="subscribe.0"></a> <a href="#pollable"><a href="#pollable"><code>pollable</code></a></a></li>
 </ul>
 <h4><a name="shutdown"><code>shutdown: func</code></a></h4>
-<p>Gracefully shut down the connection.</p>
+<p>Initiate a graceful shutdown.</p>
 <ul>
 <li>receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 operations on the <a href="#input_stream"><code>input-stream</code></a> associated with this socket will return an End Of Stream indication.
@@ -1373,8 +1405,9 @@ operations on the <a href="#output_stream"><code>output-stream</code></a> associ
 <p>Create a new TCP socket.</p>
 <p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)</code> in POSIX.</p>
 <p>This function does not require a network capability handle. This is considered to be safe because
-at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <a href="#bind"><code>bind</code></a>/<a href="#listen"><code>listen</code></a>/<a href="#connect"><code>connect</code></a>
+at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <code>bind</code>/<code>listen</code>/<code>connect</code>
 is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>
+<p>All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>not-supported</code>:                The host does not support TCP sockets. (EOPNOTSUPP)</li>
@@ -1473,6 +1506,7 @@ After which, you should release the stream with <a href="#drop_resolve_address_s
 <li><code>name-unresolvable</code>:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)</li>
 <li><code>temporary-resolver-failure</code>: A temporary failure in name resolution occurred. (EAI_AGAIN)</li>
 <li><code>permanent-resolver-failure</code>: A permanent failure in name resolution occurred. (EAI_FAIL)</li>
+<li><code>would-block</code>:                A result is not available yet. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
 <h5>Params</h5>
 <ul>
@@ -1488,31 +1522,6 @@ After which, you should release the stream with <a href="#drop_resolve_address_s
 <h5>Params</h5>
 <ul>
 <li><a name="drop_resolve_address_stream.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
-</ul>
-<h4><a name="non_blocking"><code>non-blocking: func</code></a></h4>
-<p>Get/set the blocking mode of the stream.</p>
-<p>By default a stream is in &quot;blocking&quot; mode, meaning that any function blocks and waits for its completion.
-When switched to &quot;non-blocking&quot; mode, operations that would block return an <code>again</code> error. After which
-the API consumer is expected to call <a href="#subscribe"><code>subscribe</code></a> and wait for completion using the wasi-poll module.</p>
-<p>Note: these functions are here for WASI Preview2 only.
-They're planned to be removed when <code>future</code> is natively supported in Preview3.</p>
-<h5>Params</h5>
-<ul>
-<li><a name="non_blocking.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="non_blocking.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="set_non_blocking"><code>set-non-blocking: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="set_non_blocking.this"><code>this</code></a>: <a href="#resolve_address_stream"><a href="#resolve_address_stream"><code>resolve-address-stream</code></a></a></li>
-<li><a name="set_non_blocking.value"><code>value</code></a>: <code>bool</code></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="set_non_blocking.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="subscribe"><code>subscribe: func</code></a></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the stream is ready for I/O.</p>

--- a/wit/ip-name-lookup.wit
+++ b/wit/ip-name-lookup.wit
@@ -53,25 +53,13 @@ default interface ip-name-lookup {
 	/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
 	/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
 	/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+	/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
 	resolve-next-address: func(this: resolve-address-stream) -> result<option<ip-address>, error-code>
-
-
 
 	/// Dispose of the specified `resolve-address-stream`, after which it may no longer be used.
 	/// 
 	/// Note: this function is scheduled to be removed when Resources are natively supported in Wit.
 	drop-resolve-address-stream: func(this: resolve-address-stream)
-
-	/// Get/set the blocking mode of the stream.
-	/// 
-	/// By default a stream is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `again` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	non-blocking: func(this: resolve-address-stream) -> result<bool, error-code>
-	set-non-blocking: func(this: resolve-address-stream, value: bool) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the stream is ready for I/O.
 	/// 

--- a/wit/network.wit
+++ b/wit/network.wit
@@ -51,10 +51,18 @@ default interface network {
 		/// This operation is incompatible with another asynchronous operation that is already in progress.
 		concurrency-conflict,
 
+		/// Trying to finish an asynchronous operation that:
+		/// - has not been started yet, or:
+		/// - was already finished by a previous `finish-*` call.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		not-in-progress,
+
 		/// The operation has been aborted because it could not be completed immediately.
 		/// 
 		/// Note: this is scheduled to be removed when `future`s are natively supported.
 		would-block,
+
 
 		// ### IP ERRORS ###
 

--- a/wit/network.wit
+++ b/wit/network.wit
@@ -51,6 +51,10 @@ default interface network {
 		/// This operation is incompatible with another asynchronous operation that is already in progress.
 		concurrency-conflict,
 
+		/// The operation has been aborted because it could not be completed immediately.
+		/// 
+		/// Note: this is scheduled to be removed when `future`s are natively supported.
+		would-block,
 
 		// ### IP ERRORS ###
 

--- a/wit/tcp-create-socket.wit
+++ b/wit/tcp-create-socket.wit
@@ -11,6 +11,8 @@ default interface tcp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support TCP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -98,6 +98,7 @@ default interface tcp {
 	/// 
 	/// # Typical errors
 	/// - `not-listening`: Socket is not in the Listener state. (EINVAL)
+	/// - `would-block`:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// Host implementations must skip over transient errors returned by the native accept syscall.
 	/// 
@@ -199,27 +200,13 @@ default interface tcp {
 	send-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
 	set-send-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
-	/// Get/set the blocking mode of the socket.
-	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `would-block` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	/// 
-	/// # Typical errors
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	non-blocking: func(this: tcp-socket) -> result<bool, error-code>
-	set-non-blocking: func(this: tcp-socket, value: bool) -> result<_, error-code>
-
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 
 	/// Note: this function is here for WASI Preview2 only.
 	/// It's planned to be removed when `future` is natively supported in Preview3.
 	subscribe: func(this: tcp-socket) -> pollable
 
-	/// Gracefully shut down the connection.
+	/// Initiate a graceful shutdown.
 	/// 
 	/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 	///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -29,20 +29,27 @@ default interface tcp {
 	/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 	/// implicitly bind the socket.
 	/// 
-	/// # Typical errors
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
 	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
 	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Connect to a remote endpoint.
 	/// 
@@ -50,44 +57,56 @@ default interface tcp {
 	/// - the socket is transitioned into the Connection state
 	/// - a pair of streams is returned that can be used to read & write to the connection
 	/// 
-	/// # Typical errors
-	/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
-	/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
-	/// - `connection-reset`:          The connection was reset. (ECONNRESET)
-	/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// # Typical `start` errors
 	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
 	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
 	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
 	/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
-	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+	/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+	/// - `connection-reset`:          The connection was reset. (ECONNRESET)
+	/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-	connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<tuple<input-stream, output-stream>, error-code>
+	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: tcp-socket) -> result<tuple<input-stream, output-stream>, error-code>
 
 	/// Start listening for new connections.
 	/// 
 	/// Transitions the socket into the Listener state.
 	/// 
-	/// # Typical errors
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
 	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `listen` must be identical to the one passed to `bind`.
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
 	/// - `already-listening`:         The socket is already in the Listener state.
-	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
 	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)
+	///
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+	/// - `not-in-progress`:           A `listen` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	///
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-	listen: func(this: tcp-socket, network: network) -> result<_, error-code>
+	start-listen: func(this: tcp-socket, network: network) -> result<_, error-code>
+	finish-listen: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Accept a new client socket.
 	/// 

--- a/wit/udp-create-socket.wit
+++ b/wit/udp-create-socket.wit
@@ -11,6 +11,8 @@ default interface udp-create-socket {
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
 	/// 
+	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+	/// 
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support UDP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -30,20 +30,27 @@ default interface udp {
 	/// 
 	/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
 	/// 
-	/// # Typical errors
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
 	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 	/// - `already-bound`:             The socket is already bound. (EINVAL)
+	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
 	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// - `not-in-progress`:           A `bind` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	start-bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
+	finish-bind: func(this: udp-socket) -> result<_, error-code>
 
 	/// Set the destination address.
 	/// 
@@ -55,20 +62,27 @@ default interface udp {
 	/// 
 	/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
 	/// 
-	/// # Typical errors
+	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// 
+	/// # Typical `start` errors
 	/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// 
+	/// # Typical `finish` errors
+	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+	/// - `not-in-progress`:           A `connect` operation is not in progress.
+	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-	connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	start-connect: func(this: udp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	finish-connect: func(this: udp-socket) -> result<_, error-code>
 
 	/// Receive a message.
 	/// 

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -79,6 +79,7 @@ default interface udp {
 	/// # Typical errors
 	/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
 	/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+	/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
@@ -103,6 +104,7 @@ default interface udp {
 	/// - `not-bound`:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
 	/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 	/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+	/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
@@ -181,20 +183,6 @@ default interface udp {
 	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
 	send-buffer-size: func(this: udp-socket) -> result<u64, error-code>
 	set-send-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
-
-	/// Get/set the blocking mode of the socket.
-	/// 
-	/// By default a socket is in "blocking" mode, meaning that any function blocks and waits for its completion.
-	/// When switched to "non-blocking" mode, operations that would block return an `would-block` error. After which
-	/// the API consumer is expected to call `subscribe` and wait for completion using the wasi-poll module.
-	/// 
-	/// Note: these functions are here for WASI Preview2 only.
-	/// They're planned to be removed when `future` is natively supported in Preview3.
-	/// 
-	/// # Typical errors
-	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-	non-blocking: func(this: udp-socket) -> result<bool, error-code>
-	set-non-blocking: func(this: udp-socket, value: bool) -> result<_, error-code>
 
 	/// Create a `pollable` which will resolve once the socket is ready for I/O.
 	/// 


### PR DESCRIPTION
- Removed the non-blocking toggle on resources. They're now always non-blocking.
- Made the following functions async:
  - tcp::bind,
  - tcp::listen,
  - tcp::connect,
  - udp::bind,
  - udp::connect
