### PR TITLE
Remove the `network` parameter from `start-listen`.

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -1112,10 +1112,14 @@ implicitly bind the socket.</p>
 <h4><a name="start_listen"><code>start-listen: func</code></a></h4>
 <p>Start listening for new connections.</p>
 <p>Transitions the socket into the Listener state.</p>
-<p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
+<p>Unlike POSIX:</p>
+<ul>
+<li>this function is async. This enables interactive WASI hosts to inject permission prompts.</li>
+<li>the socket must already be explicitly bound.</li>
+</ul>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>not-bound</code>:                 The socket is not bound to any local address.</li>
+<li><code>not-bound</code>:                 The socket is not bound to any local address. (EDESTADDRREQ)</li>
 <li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)</li>
 <li><code>already-listening</code>:         The socket is already in the Listener state.</li>
 <li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EINVAL on BSD)</li>

--- a/example-world.md
+++ b/example-world.md
@@ -1115,7 +1115,7 @@ implicitly bind the socket.</p>
 <p>Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.</p>
 <h1>Typical <code>start</code> errors</h1>
 <ul>
-<li><code>already-attached</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <code>listen</code> must be identical to the one passed to <code>bind</code>.</li>
+<li><code>not-bound</code>:                 The socket is not bound to any local address.</li>
 <li><code>already-connected</code>:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)</li>
 <li><code>already-listening</code>:         The socket is already in the Listener state.</li>
 <li><code>concurrency-conflict</code>:      Another <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EINVAL on BSD)</li>
@@ -1136,7 +1136,6 @@ implicitly bind the socket.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="start_listen.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="start_listen.network"><a href="#network"><code>network</code></a></a>: <a href="#network"><a href="#network"><code>network</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -87,7 +87,9 @@ default interface tcp {
 	/// 
 	/// Transitions the socket into the Listener state.
 	/// 
-	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// Unlike POSIX:
+	/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
+	/// - the socket must already be explicitly bound.
 	/// 
 	/// # Typical `start` errors
 	/// - `not-bound`:                 The socket is not bound to any local address. (EDESTADDRREQ)

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -90,7 +90,7 @@ default interface tcp {
 	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
 	/// # Typical `start` errors
-	/// - `not-bound`:                 The socket is not bound to any local address.
+	/// - `not-bound`:                 The socket is not bound to any local address. (EDESTADDRREQ)
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
 	/// - `already-listening`:         The socket is already in the Listener state.
 	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -90,7 +90,7 @@ default interface tcp {
 	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
 	/// # Typical `start` errors
-	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `listen` must be identical to the one passed to `bind`.
+	/// - `not-bound`:                 The socket is not bound to any local address.
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
 	/// - `already-listening`:         The socket is already in the Listener state.
 	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)
@@ -105,7 +105,7 @@ default interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-	start-listen: func(this: tcp-socket, network: network) -> result<_, error-code>
+	start-listen: func(this: tcp-socket) -> result<_, error-code>
 	finish-listen: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Accept a new client socket.


### PR DESCRIPTION
As discussed in #28, remove the network parameter from the `start-listen` function.

Also, document that `start-listen` fails if the socket is not bound. This ensures the the address is checked against the network before starting to listen.