### PR TITLE
Merge `start-bind` and `finish-bind` into a single `bind`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
         ./wit-deps lock
         git add -N wit/deps
         git diff --exit-code
-    - uses: WebAssembly/wit-abi-up-to-date@v12
+    - uses: WebAssembly/wit-abi-up-to-date@v13
       with:
-        wit-abi-tag: wit-abi-0.10.0
+        wit-abi-tag: wit-abi-0.11.0

--- a/Posix-compatibility.md
+++ b/Posix-compatibility.md
@@ -39,11 +39,11 @@ Not included in proposal. WASI has no concept of UNIX-style processes.
 - UDP: [`udp::start-connect`](udp) & [`udp::finish-connect`](udp)
 
 ### `bind`
-- TCP: [`tcp::start-bind`](tcp) & [`tcp::finish-bind`](tcp)
-- UDP: [`udp::start-bind`](udp) & [`udp::finish-bind`](udp)
+- TCP: [`tcp::bind`](tcp)
+- UDP: [`udp::bind`](udp)
 
 ### `listen`
-- TCP: [`tcp::start-listen`](tcp) & [`tcp::finish-listen`](tcp). The `backlog` parameter has been split out into a distinct function [`tcp::set-listen-backlog-size`](tcp) ([See #34](https://github.com/WebAssembly/wasi-sockets/issues/34)).
+- TCP: [`tcp::listen`](tcp). The `backlog` parameter has been split out into a distinct function [`tcp::set-listen-backlog-size`](tcp) ([See #34](https://github.com/WebAssembly/wasi-sockets/issues/34)).
 - UDP: N/A
 
 ### `accept`, `accept4` (non-standard)

--- a/wit/network.wit
+++ b/wit/network.wit
@@ -48,9 +48,6 @@ interface network {
 		/// The operation timed out before it could finish completely.
 		timeout,
 
-		/// This operation is incompatible with another asynchronous operation that is already in progress.
-		concurrency-conflict,
-
 		/// Trying to finish an asynchronous operation that:
 		/// - has not been started yet, or:
 		/// - was already finished by a previous `finish-*` call.
@@ -94,7 +91,9 @@ interface network {
 		/// The socket is already bound.
 		already-bound,
 
-		/// The socket is already in the Connection state.
+		/// `start-connect` has been called on the socket, so it's either in the
+		/// progress of establishing a connection, or it's already in the
+                /// Connection state.
 		already-connected,
 
 		/// The socket is not bound to any local address.

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -31,25 +31,20 @@ interface tcp {
 	/// 
 	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// # Typical `start` errors
+	/// # Typical errors
 	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 	/// - `already-bound`:             The socket is already bound. (EINVAL)
-	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	/// 
-	/// # Typical `finish` errors
+	/// - `already-connected`:         The socket is already in the Connection state. (EINVAL)
 	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-	/// - `not-in-progress`:           A `bind` operation is not in progress.
-	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	/// 
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
-	finish-bind: func(this: tcp-socket) -> result<_, error-code>
+	bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
 
 	/// Connect to a remote endpoint.
 	/// 
@@ -64,7 +59,7 @@ interface tcp {
 	/// - `already-attached`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
 	/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
-	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	/// - `already-bound`:             The socket is already bound. (EINVAL)
 	/// 
 	/// # Typical `finish` errors
 	/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
@@ -91,24 +86,18 @@ interface tcp {
 	/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// - the socket must already be explicitly bound.
 	/// 
-	/// # Typical `start` errors
+	/// # Typical errors
 	/// - `not-bound`:                 The socket is not bound to any local address. (EDESTADDRREQ)
 	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
 	/// - `already-listening`:         The socket is already in the Listener state.
-	/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EINVAL on BSD)
-	///
-	/// # Typical `finish` errors
 	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
-	/// - `not-in-progress`:           A `listen` operation is not in progress.
-	/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
 	///
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
 	/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-	start-listen: func(this: tcp-socket) -> result<_, error-code>
-	finish-listen: func(this: tcp-socket) -> result<_, error-code>
+	listen: func(this: tcp-socket) -> result<_, error-code>
 
 	/// Accept a new client socket.
 	/// 
@@ -166,8 +155,8 @@ interface tcp {
 	/// # Typical errors
 	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `already-connected`:    (set) The socket is already connected.
 	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	ipv6-only: func(this: tcp-socket) -> result<bool, error-code>
 	set-ipv6-only: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
@@ -175,20 +164,17 @@ interface tcp {
 	/// 
 	/// # Typical errors
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Equivalent to the SO_KEEPALIVE socket option.
 	/// 
 	/// # Typical errors
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	keep-alive: func(this: tcp-socket) -> result<bool, error-code>
 	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the TCP_NODELAY socket option.
 	/// 
 	/// # Typical errors
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	no-delay: func(this: tcp-socket) -> result<bool, error-code>
 	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error-code>
 	
@@ -197,7 +183,6 @@ interface tcp {
 	/// # Typical errors
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
 	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
 
@@ -215,7 +200,6 @@ interface tcp {
 	/// # Typical errors
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
-	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	receive-buffer-size: func(this: tcp-socket) -> result<u64, error-code>
 	set-receive-buffer-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 	send-buffer-size: func(this: tcp-socket) -> result<u64, error-code>

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -32,12 +32,10 @@ interface udp {
 	/// 
 	/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
 	/// 
-	/// # Typical `start` errors
+	/// # Typical errors
 	/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 	/// - `already-bound`:             The socket is already bound. (EINVAL)
-	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
-	/// 
-	/// # Typical `finish` errors
+	/// - `already-connected`:         The socket is already connected. (EINVAL)
 	/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 	/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 	/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
@@ -49,8 +47,7 @@ interface udp {
 	/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-	start-bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
-	finish-bind: func(this: udp-socket) -> result<_, error-code>
+	bind: func(this: udp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
 
 	/// Set the destination address.
 	/// 
@@ -69,7 +66,7 @@ interface udp {
 	/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-	/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
+	/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
 	/// 
 	/// # Typical `finish` errors
 	/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
@@ -177,15 +174,14 @@ interface udp {
 	/// # Typical errors
 	/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 	/// - `already-bound`:        (set) The socket is already bound.
+	/// - `already-connected`:    (set) The socket is already connected.
 	/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
 	ipv6-only: func(this: udp-socket) -> result<bool, error-code>
 	set-ipv6-only: func(this: udp-socket, value: bool) -> result<_, error-code>
 
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 	/// 
 	/// # Typical errors
-	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
 	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
 	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
 
@@ -203,7 +199,6 @@ interface udp {
 	/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
 	/// 
 	/// # Typical errors
-	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
 	receive-buffer-size: func(this: udp-socket) -> result<u64, error-code>
 	set-receive-buffer-size: func(this: udp-socket, value: u64) -> result<_, error-code>
 	send-buffer-size: func(this: udp-socket) -> result<u64, error-code>


### PR DESCRIPTION
Similarly, merge `start-listen` and `finish-listen` into a single `listen`. The underlying `bind` and `listen` operations don't do any network I/O; they just modify the local state of a socket. And they aren't considered blocking in common host OS implementations. So it simplifies both host and guest code to combine these into single functions that just do the work directly.

After this change, the only `start-`/`finish-` pair remaining is `start-connect`/`finish-connect`. I believe that makes sense to keep as-is because it pretty closely corresponds to how POSIX `connect` behaves on non-blocking sockets.

With this change, I also think it makes sense to remove the `concurrency-conflict` error code, and just use `already-connected` for the cases where an operation doesn't work if a connection is either established or in the process of being established.