### PR TITLE
Support more socket options

### DIFF
--- a/Posix-compatibility.md
+++ b/Posix-compatibility.md
@@ -151,24 +151,24 @@ Columns:
 | SO_DOMAIN                       | ✅       | ❌     | ✅    | ✅      | ❌     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::address-family`](tcp)<br/>[`udp::address-family`](udp) <br/><br/> SO_PROTOCOL_INFO on Windows. |
 | SO_TYPE                         | ✅*      | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ✅  | ✅      | ✅    | ✅    | ❌    | ✅   | * indirectly through the type of the socket resource. |
 | SO_PROTOCOL                     | ✅*      | ❌     | ✅    | ✅      | ❌     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | * indirectly through the type of the socket resource. SO_PROTOCOL_INFO on Windows. |
-| SO_ACCEPTCONN                   | ❔       | ✅     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
+| SO_ACCEPTCONN                   | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::is-listening`](tcp) |
 | IPV6_V6ONLY                     | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ✅      | ❌    | ✅    | ✅    | ✅   | [`tcp::(set-)ipv6-only`](tcp)<br/>[`udp::(set-)ipv6-only`](udp) |
 | IP_HDRINCL                      | ⛔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Out of scope. Raw sockets only. |
 | IPV6_HDRINCL                    | ⛔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Out of scope. Raw sockets only. |
-| IP_TTL                          | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)unicast-hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
-| IPV6_UNICAST_HOPS               | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)unicast-hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
-| IP_RECVTTL                      | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
-| IPV6_RECVHOPLIMIT               | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
-| IP_TOS                          | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | |
-| IPV6_TCLASS                     | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | |
-| IP_RECVTOS                      | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | |
-| IPV6_RECVTCLASS                 | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | |
-| IP_RECVPKTINFO                  | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IP_PKTINFO on Linux & Windows, IP_RECVDSTADDR+IP_RECVIF on MacOS & FreeBSD. |
-| IPV6_RECVPKTINFO                | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IPV6_PKTINFO on Windows. |
-| IP_DONTFRAG                     | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IP_DONTFRAGMENT on Windows, implementable using IP_MTU_DISCOVER on Linux. |
-| IPV6_DONTFRAG                   | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | |
-| IP_MTU_DISCOVER                 | ❔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | |
-| IPV6_MTU_DISCOVER               | ❔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | |
+| IP_TTL                          | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
+| IPV6_UNICAST_HOPS               | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
+| IP_RECVTTL                      | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | See [`udp::receive`](udp) |
+| IPV6_RECVHOPLIMIT               | ✅       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | See [`udp::receive`](udp) |
+| IP_TOS                          | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | [`tcp::(set-)traffic-class`](tcp)<br/>[`udp::(set-)traffic-class`](udp) |
+| IPV6_TCLASS                     | ✅       | ❌     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | [`tcp::(set-)traffic-class`](tcp)<br/>[`udp::(set-)traffic-class`](udp) |
+| IP_RECVTOS                      | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | See [`udp::receive`](udp) |
+| IPV6_RECVTCLASS                 | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | See [`udp::receive`](udp) |
+| IP_RECVPKTINFO                  | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | See [`udp::receive`](udp) <br/><br/> IP_PKTINFO on Linux & Windows, IP_RECVDSTADDR+IP_RECVIF on MacOS & FreeBSD. |
+| IPV6_RECVPKTINFO                | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | See [`udp::receive`](udp) <br/><br/> IPV6_PKTINFO on Windows. |
+| IP_DONTFRAG                     | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | [`udp::(set-)dont-fragment`](udp) <br/><br/> IP_DONTFRAGMENT on Windows, implementable using IP_MTU_DISCOVER on Linux. |
+| IPV6_DONTFRAG                   | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | [`udp::(set-)dont-fragment`](udp) |
+| IP_MTU_DISCOVER                 | ❔*      | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | Only the "Don't fragment" behaviour is supported as part of IP_DONTFRAG. |
+| IPV6_MTU_DISCOVER               | ❔*      | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | Only the "Don't fragment" behaviour is supported as part of IP_DONTFRAG. |
 | SO_RCVBUF                       | ✅       | ✅     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ❌    | ✅    | ❌   | [`tcp::(set-)receive-buffer-size`](tcp)<br/>[`udp::(set-)receive-buffer-size`](udp) |
 | SO_SNDBUF                       | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | [`tcp::(set-)send-buffer-size`](tcp)<br/>[`udp::(set-)send-buffer-size`](udp) |
 | SO_RCVLOWAT                     | ❔       | ✅     | ✅    | ❌      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
@@ -176,11 +176,11 @@ Columns:
 | SO_RCVTIMEO                     | ⛔       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ❌      | ❌  | ✅      | ❌    | ✅    | ❌    | ❌   | WASI sockets are always non-blocking. Timeouts can be recreated in libc. |
 | SO_SNDTIMEO                     | ⛔       | ✅     | ❌    | ✅      | ✅     | ✅      | ❌    | ✅    | ✅   | ❌      | ❌  | ✅      | ❌    | ❌    | ❌    | ❌   | WASI sockets are always non-blocking. Timeouts can be recreated in libc. |
 | SO_KEEPALIVE                    | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ✅      | ✅    | ✅    | ❌    | ✅   | [`tcp::(set-)keep-alive`](tcp) |
-| TCP_KEEPCNT                     | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ✅    | ❌    | ❌    | ❌   | |
-| TCP_KEEPIDLE                    | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | TCP_KEEPALIVE on MacOS |
-| TCP_KEEPINTVL                   | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | |
+| TCP_KEEPCNT                     | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ✅    | ❌    | ❌    | ❌   | [`tcp::(set-)keep-alive-count`](tcp) |
+| TCP_KEEPIDLE                    | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | [`tcp::(set-)keep-alive-idle-time`](tcp) <br/><br/> TCP_KEEPALIVE on MacOS |
+| TCP_KEEPINTVL                   | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | [`tcp::(set-)keep-alive-interval`](tcp) |
 | TCP_NODELAY                     | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ✅  | ✅      | ✅    | ✅    | ❌    | ✅   | [`tcp::(set-)no-delay`](tcp) |
-| TCP_CORK                        | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ✅    | ❌    | ❌    | ✅   | TCP_NOPUSH on MacOS & FreeBSD |
+| TCP_CORK                        | ✅       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ✅    | ❌    | ❌    | ✅   | [`tcp::(set-)no-push`](tcp) <br/><br/> TCP_NOPUSH on MacOS & FreeBSD |
 | SO_LINGER                       | ❔       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ✅  | ✅      | ✅    | ❌    | ❌    | ❌   | |
 | SO_OOBINLINE                    | ⛔       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Not supported, see [OOB](#oob) |
 | SO_DEBUG                        | ❔       | ✅     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
@@ -210,8 +210,8 @@ Columns:
 | IP_UNBLOCK_SOURCE               | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Equivalent to MCAST_UNBLOCK_SOURCE |
 | IP_MSFILTER                     | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | TCP_INFO                        | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ✅    | ❌    | ❌    | ✅   | |
-| TCP_FASTOPEN                    | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ❌    | ✅   | |
-| TCP_FASTOPEN_CONNECT            | ❔       | ❌     | ✅    | ❌      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ❌    | ✅    | ❌    | ✅   | |
+| TCP_FASTOPEN                    | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ❌    | ✅   | [`tcp::(set-)fast-open`](tcp). Also, see the `initial-data` parameter of `connect`. |
+| TCP_FASTOPEN_CONNECT            | ✅*      | ❌     | ✅    | ❌      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ❌    | ✅    | ❌    | ✅   | * As TCP_FASTOPEN |
 | TCP_FASTOPEN_KEY                | ❔       | ❌     | ✅    | ❌      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | TCP_FASTOPEN_NO_COOKIE          | ❔       | ❌     | ✅    | ❌      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | TCP_FASTOPEN_FORCE_ENABLE       | ❔       | ❌     | ❌    | ❌      | ✅     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |

--- a/example-world.md
+++ b/example-world.md
@@ -81,7 +81,10 @@ There is no need for this to map 1:1 to a physical network interface.
 <li><a name="ip_address.ipv4"><code>ipv4</code></a>: <a href="#ipv4_address"><a href="#ipv4_address"><code>ipv4-address</code></a></a></li>
 <li><a name="ip_address.ipv6"><code>ipv6</code></a>: <a href="#ipv6_address"><a href="#ipv6_address"><code>ipv6-address</code></a></a></li>
 </ul>
-<h4><a name="error_code"><code>enum error-code</code></a></h4>
+<h4><a name="interface_id"><code>type interface-id</code></a></h4>
+<p><code>u32</code></p>
+<p>
+#### <a name="error_code">`enum error-code`</a>
 <p>Error codes.</p>
 <p>In theory, every API can return any error code.
 In practice, API's typically only return the errors documented per API
@@ -319,6 +322,9 @@ mean &quot;ready&quot;.</p>
 #### <a name="ip_address_family">`type ip-address-family`</a>
 [`ip-address-family`](#ip_address_family)
 <p>
+#### <a name="interface_id">`type interface-id`</a>
+[`interface-id`](#interface_id)
+<p>
 #### <a name="udp_socket">`type udp-socket`</a>
 `u32`
 <p>A UDP socket handle.
@@ -339,6 +345,11 @@ Equivalent to the <code>dest_addr</code> parameter of <code>sendto</code> and th
 <li>
 <p><a name="datagram.local_address"><a href="#local_address"><code>local-address</code></a></a>: option&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>&gt;</p>
 <p>The local address.
+<p>Equivalent to the IP_PKTINFO &amp; IPV6_PKTINFO ancillary messages.</p>
+</li>
+<li>
+<p><a name="datagram.local_interface"><code>local-interface</code></a>: option&lt;<a href="#interface_id"><a href="#interface_id"><code>interface-id</code></a></a>&gt;</p>
+<p>The local interface.
 <p>Equivalent to the IP_PKTINFO &amp; IPV6_PKTINFO ancillary messages.</p>
 </li>
 <li>
@@ -459,7 +470,7 @@ The returned list may contain fewer elements than requested, but never more.
 If <code>max-results</code> is 0, this function returns successfully with an empty list.</p>
 <p>The closest equivalent to this function is Linux' <code>recvmmsg</code> function while having the following options enabled:</p>
 <ul>
-<li>IP_PKTINFO/IP_RECVDSTADDR or IPV6_RECVPKTINFO</li>
+<li>IP_PKTINFO/IP_RECVDSTADDR+IP_RECVIF or IPV6_RECVPKTINFO</li>
 <li>IP_RECVTOS or IPV6_RECVTCLASS</li>
 <li>IP_RECVTTL or IPV6_RECVHOPLIMIT</li>
 </ul>
@@ -501,6 +512,7 @@ If at least one datagram has been sent successfully, this function never returns
 <ul>
 <li><a href="#remote_address"><code>remote-address</code></a>: The packet will be sent to the connected <a href="#remote_address"><code>remote-address</code></a>. Or fail if not connected.</li>
 <li><a href="#local_address"><code>local-address</code></a>: The system will choose a suitable source address.</li>
+<li><code>local-interface</code>: The system will choose a suitable interface.</li>
 <li><a href="#traffic_class"><code>traffic-class</code></a>: The value of the <a href="#traffic_class"><code>traffic-class</code></a> socket option (below) will be used.</li>
 <li><a href="#hop_limit"><code>hop-limit</code></a>: The value of the <a href="#unicast_hop_limit"><code>unicast-hop-limit</code></a> socket option (below) will be used.</li>
 </ul>

--- a/example-world.md
+++ b/example-world.md
@@ -326,7 +326,7 @@ mean &quot;ready&quot;.</p>
 <h5>Record Fields</h5>
 <ul>
 <li><a name="datagram.data"><code>data</code></a>: list&lt;<code>u8</code>&gt;</li>
-<li><a name="datagram.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li><a name="datagram.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: option&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>&gt;</li>
 </ul>
 <hr />
 <h3>Functions</h3>
@@ -466,14 +466,13 @@ returns how many messages were actually sent (or queued for sending).</p>
 sending each individual datagram until either the end of the list has been reached or the first error occurred.
 If at least one datagram has been sent successfully, this function never returns an error.</p>
 <p>If the input list is empty, the function returns <code>ok(0)</code>.</p>
-<p>The remote address option is required. To send a message to the &quot;connected&quot; peer,
-call <a href="#remote_address"><code>remote-address</code></a> to get their address.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>address-family-mismatch</code>: The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
 <li><code>invalid-remote-address</code>:  The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-remote-address</code>:  The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and the <code>datagram.remote-address</code> does not match the address passed to <code>connect</code>. (EISCONN)</li>
+<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and <a href="#remote_address"><code>remote-address</code></a> is <code>some</code> value that does not match the address passed to <code>connect</code>. (EISCONN)</li>
+<li><code>not-connected</code>:           The socket is not &quot;connected&quot; and no value for <a href="#remote_address"><code>remote-address</code></a> was provided. (EDESTADDRREQ)</li>
 <li><code>not-bound</code>:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.</li>
 <li><code>remote-unreachable</code>:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
 <li><code>datagram-too-large</code>:      The datagram is too large. (EMSGSIZE)</li>

--- a/wit/network.wit
+++ b/wit/network.wit
@@ -183,4 +183,5 @@ interface network {
 		ipv6(ipv6-socket-address),
 	}
 
+	type interface-id = u32
 }

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -4,9 +4,15 @@ interface tcp {
 	use wasi:poll/poll.{pollable}
 	use network.{network, error-code, ip-socket-address, ip-address-family}
 
+	/// Amount of time in nanoseconds.
+	/// This is a placeholder type, in the hope that WASI someday will have a central package for time-related types.
+	/// `wasi-clocks` currently doesn't have a sufficient type.
+	/// To accomodate the possibility that an eventual Duration may be signed, all wasi-socket implementations must trap if they encounter a duration >= 2^63
+	type duration = u64
+
 	/// A TCP socket handle.
 	type tcp-socket = u32
-	
+
 
 	enum shutdown-type {
 		/// Similar to `SHUT_RD` in POSIX.
@@ -51,7 +57,10 @@ interface tcp {
 	start-bind: func(this: tcp-socket, network: network, local-address: ip-socket-address) -> result<_, error-code>
 	finish-bind: func(this: tcp-socket) -> result<_, error-code>
 
-	/// Connect to a remote endpoint.
+	/// Connect to a remote endpoint and optionally send some data.
+	/// 
+	/// This operation does not finish until all initial data has been written, or an error has occurred.
+	/// If `fast-open` is enabled, some of `initial-data` may be sent as part of the opening handshake.
 	/// 
 	/// On success:
 	/// - the socket is transitioned into the Connection state
@@ -80,7 +89,7 @@ interface tcp {
 	/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 	/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address) -> result<_, error-code>
+	start-connect: func(this: tcp-socket, network: network, remote-address: ip-socket-address, initial-data: list<u8>) -> result<_, error-code>
 	finish-connect: func(this: tcp-socket) -> result<tuple<input-stream, output-stream>, error-code>
 
 	/// Start listening for new connections.
@@ -154,6 +163,11 @@ interface tcp {
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
 	remote-address: func(this: tcp-socket) -> result<ip-socket-address, error-code>
 
+	/// Whether the socket is listening for new connections.
+	/// 
+	/// Equivalent to the SO_ACCEPTCONN socket option.
+	is-listening: func(this: tcp-socket) -> bool
+
 	/// Whether this is a IPv4 or IPv6 socket.
 	/// 
 	/// Equivalent to the SO_DOMAIN socket option.
@@ -176,6 +190,7 @@ interface tcp {
 	/// # Typical errors
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	listen-backlog-size: func(this: tcp-socket) -> result<u64, error-code>
 	set-listen-backlog-size: func(this: tcp-socket, value: u64) -> result<_, error-code>
 
 	/// Equivalent to the SO_KEEPALIVE socket option.
@@ -185,12 +200,40 @@ interface tcp {
 	keep-alive: func(this: tcp-socket) -> result<bool, error-code>
 	set-keep-alive: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
+	/// Equivalent to the TCP_KEEPIDLE socket option.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	keep-alive-idle-time: func(this: tcp-socket) -> result<duration, error-code>
+	set-keep-alive-idle-time: func(this: tcp-socket, value: duration) -> result<_, error-code>
+
+	/// Equivalent to the TCP_KEEPINTVL socket option.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	keep-alive-interval: func(this: tcp-socket) -> result<duration, error-code>
+	set-keep-alive-interval: func(this: tcp-socket, value: duration) -> result<_, error-code>
+
+	/// Equivalent to the TCP_KEEPCNT socket option.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	keep-alive-count: func(this: tcp-socket) -> result<u32, error-code>
+	set-keep-alive-count: func(this: tcp-socket, value: u32) -> result<_, error-code>
+
 	/// Equivalent to the TCP_NODELAY socket option.
 	/// 
 	/// # Typical errors
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
 	no-delay: func(this: tcp-socket) -> result<bool, error-code>
 	set-no-delay: func(this: tcp-socket, value: bool) -> result<_, error-code>
+
+	/// Equivalent to the TCP_CORK/TCP_NOPUSH socket option.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	no-push: func(this: tcp-socket) -> result<bool, error-code>
+	set-no-push: func(this: tcp-socket, value: bool) -> result<_, error-code>
 	
 	/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
 	/// 
@@ -198,8 +241,28 @@ interface tcp {
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
-	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
+	hop-limit: func(this: tcp-socket) -> result<u8, error-code>
+	set-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
+
+	/// Equivalent to the IP_TOS & IPV6_TCLASS socket options.
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	traffic-class: func(this: tcp-socket) -> result<u8, error-code>
+	set-traffic-class: func(this: tcp-socket, value: u8) -> result<_, error-code>
+
+	/// Enable TCP Fast Open (TFO).
+	/// 
+	/// Equivalent to the TCP_FASTOPEN socket options.
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	fast-open: func(this: tcp-socket) -> result<bool, error-code>
+	set-fast-open: func(this: tcp-socket, value: bool) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -10,7 +10,7 @@ interface udp {
 
 	record datagram {
 		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
-		remote-address: ip-socket-address,
+		remote-address: option<ip-socket-address>,
 
 		/// Possible future additions:
 		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
@@ -117,14 +117,12 @@ interface udp {
 	/// 
 	/// If the input list is empty, the function returns `ok(0)`.
 	/// 
-	/// The remote address option is required. To send a message to the "connected" peer,
-	/// call `remote-address` to get their address.
-	/// 
 	/// # Typical errors
 	/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 	/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `invalid-remote-address`:  The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-	/// - `already-connected`:       The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+	/// - `already-connected`:       The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `connect`. (EISCONN)
+	/// - `not-connected`:           The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
 	/// - `not-bound`:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
 	/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 	/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -9,15 +9,33 @@ interface udp {
 
 
 	record datagram {
-		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+		/// The payload.
+		/// 
+		/// Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+		data: list<u8>,
+
+		/// The peer address.
+		/// 
+		/// Equivalent to the `src_addr` out parameter of `recvfrom` and the `msghdr::msg_name` out parameter of `recvmsg`.
+		/// Equivalent to the `dest_addr` parameter of `sendto` and the `msghdr::msg_name` parameter of `sendmsg`.
 		remote-address: option<ip-socket-address>,
 
-		/// Possible future additions:
-		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
-		/// local-interface: u32, // IP_PKTINFO / IP_RECVIF
-		/// ttl: u8, // IP_RECVTTL
-		/// dscp: u6, // IP_RECVTOS
-		/// ecn: u2, // IP_RECVTOS
+		/// The local address.
+		/// 
+		/// Equivalent to the IP_PKTINFO & IPV6_PKTINFO ancillary messages.
+		local-address: option<ip-socket-address>,
+
+		/// The value of the Traffic Class field of the IP packet. (Also known as "Type of Service (TOS)" in IPv4)
+		/// 
+		/// This value is composed of the DSCP (6 high bits) + ECN (2 low bits)
+		/// 
+		/// Equivalent to the IP_TOS & IPV6_TCLASS ancillary messages.
+		traffic-class: option<u8>,
+
+		/// The value of the Hop Limit field of the IP packet. (Also known as "Time To Live (TTL)" in IPv4)
+		/// 
+		/// Equivalent to the IP_TTL & IPV6_HOPLIMIT ancillary messages.
+		hop-limit: option<u8>,
 	}
 
 
@@ -90,6 +108,11 @@ interface udp {
 	/// The returned list may contain fewer elements than requested, but never more.
 	/// If `max-results` is 0, this function returns successfully with an empty list.
 	/// 
+	/// The closest equivalent to this function is Linux' `recvmmsg` function while having the following options enabled:
+	/// - IP_PKTINFO/IP_RECVDSTADDR or IPV6_RECVPKTINFO
+	/// - IP_RECVTOS or IPV6_RECVTCLASS
+	/// - IP_RECVTTL or IPV6_RECVHOPLIMIT
+	/// 
 	/// # Typical errors
 	/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
 	/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
@@ -116,6 +139,17 @@ interface udp {
 	/// If at least one datagram has been sent successfully, this function never returns an error.
 	/// 
 	/// If the input list is empty, the function returns `ok(0)`.
+	/// 
+	/// Most `datagram` fields are optional. When `none` is passed,
+	/// - `remote-address`: The packet will be sent to the connected `remote-address`. Or fail if not connected.
+	/// - `local-address`: The system will choose a suitable source address.
+	/// - `traffic-class`: The value of the `traffic-class` socket option (below) will be used.
+	/// - `hop-limit`: The value of the `unicast-hop-limit` socket option (below) will be used.
+	/// 
+	/// The closest equivalent to this function is Linux' `sendmmsg` function with the following ancillary messages:
+	/// - IP_PKTINFO or IPV6_PKTINFO
+	/// - IP_TOS or IPV6_TCLASS
+	/// - IP_TTL or IPV6_HOPLIMIT
 	/// 
 	/// # Typical errors
 	/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
@@ -186,6 +220,20 @@ interface udp {
 	/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
 	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
 	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
+
+	/// Equivalent to the IP_TOS & IPV6_TCLASS socket options.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	traffic-class: func(this: udp-socket) -> result<u8, error-code>
+	set-traffic-class: func(this: udp-socket, value: u8) -> result<_, error-code>
+
+	/// Equivalent to the IP_DONTFRAG & IPV6_DONTFRAG socket options.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	dont-fragment: func(this: udp-socket) -> result<u8, error-code>
+	set-dont-fragment: func(this: udp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -1,7 +1,7 @@
 
 interface udp {
 	use wasi:poll/poll.{pollable}
-	use network.{network, error-code, ip-socket-address, ip-address-family}
+	use network.{network, error-code, ip-socket-address, ip-address-family, interface-id}
 
 
 	/// A UDP socket handle.
@@ -24,6 +24,11 @@ interface udp {
 		/// 
 		/// Equivalent to the IP_PKTINFO & IPV6_PKTINFO ancillary messages.
 		local-address: option<ip-socket-address>,
+
+		/// The local interface.
+		/// 
+		/// Equivalent to the IP_PKTINFO & IPV6_PKTINFO ancillary messages.
+		local-interface: option<interface-id>,
 
 		/// The value of the Traffic Class field of the IP packet. (Also known as "Type of Service (TOS)" in IPv4)
 		/// 
@@ -109,7 +114,7 @@ interface udp {
 	/// If `max-results` is 0, this function returns successfully with an empty list.
 	/// 
 	/// The closest equivalent to this function is Linux' `recvmmsg` function while having the following options enabled:
-	/// - IP_PKTINFO/IP_RECVDSTADDR or IPV6_RECVPKTINFO
+	/// - IP_PKTINFO/IP_RECVDSTADDR+IP_RECVIF or IPV6_RECVPKTINFO
 	/// - IP_RECVTOS or IPV6_RECVTCLASS
 	/// - IP_RECVTTL or IPV6_RECVHOPLIMIT
 	/// 
@@ -143,6 +148,7 @@ interface udp {
 	/// Most `datagram` fields are optional. When `none` is passed,
 	/// - `remote-address`: The packet will be sent to the connected `remote-address`. Or fail if not connected.
 	/// - `local-address`: The system will choose a suitable source address.
+	/// - `local-interface`: The system will choose a suitable interface.
 	/// - `traffic-class`: The value of the `traffic-class` socket option (below) will be used.
 	/// - `hop-limit`: The value of the `unicast-hop-limit` socket option (below) will be used.
 	/// 


### PR DESCRIPTION
To increase compatibility with [existing software](https://github.com/WebAssembly/wasi-sockets/blob/main/Posix-compatibility.md#socket-options), this PR adds functionalities I consider simple enough to be copied almost verbatim from BSD-sockets into wasi-sockets.

### Plain getter/setters for
- SO_ACCEPTCONN
- IP_TOS/IPV6_TCLASS
- IP_DONTFRAG/IPV6_DONTFRAG
- TCP_KEEPCNT
- TCP_KEEPIDLE
- TCP_KEEPINTVL
- TCP_CORK

### Enable send-like behaviour
by making `datagram::remote-address` optional.
Fixes #49

### Send and receive ancillary data
Fixes #38

The following options are enabled by default; I doubt these 32-ish additional bytes are going to cause major performance issues.
- IP_RECVTTL/IPV6_RECVHOPLIMIT
- IP_RECVTOS/IPV6_RECVTCLASS
- IP_RECVPKTINFO/IPV6_RECVPKTINFO

### TCP Fast Open
- Updated Connect to take an `initial-data` parameter. When streams land, will be replaced by the stream input parameter.
- TCP_FASTOPEN & TCP_FASTOPEN_CONNECT

---

I intend to create followup PRs for:
- SO_LINGER
- SO_REUSEADDR and friends
- UDP broadcast & multicast

After those, usage of the remaining socket options seems to [quickly taper off](https://github.com/WebAssembly/wasi-sockets/blob/main/Posix-compatibility.md#socket-options).