### PR TITLE
UDP: Enable `send`-like behaviour

### DIFF
--- a/example-world.md
+++ b/example-world.md
@@ -325,8 +325,17 @@ mean &quot;ready&quot;.</p>
 <h4><a name="datagram"><code>record datagram</code></a></h4>
 <h5>Record Fields</h5>
 <ul>
-<li><a name="datagram.data"><code>data</code></a>: list&lt;<code>u8</code>&gt;</li>
-<li><a name="datagram.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: <a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a></li>
+<li>
+<p><a name="datagram.data"><code>data</code></a>: list&lt;<code>u8</code>&gt;</p>
+<p>The payload.
+<p>Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.</p>
+</li>
+<li>
+<p><a name="datagram.remote_address"><a href="#remote_address"><code>remote-address</code></a></a>: option&lt;<a href="#ip_socket_address"><a href="#ip_socket_address"><code>ip-socket-address</code></a></a>&gt;</p>
+<p>The peer address.
+<p>Equivalent to the <code>src_addr</code> out parameter of <code>recvfrom</code> and the <code>msghdr::msg_name</code> out parameter of <code>recvmsg</code>.
+Equivalent to the <code>dest_addr</code> parameter of <code>sendto</code> and the <code>msghdr::msg_name</code> parameter of <code>sendmsg</code>.</p>
+</li>
 </ul>
 <hr />
 <h3>Functions</h3>
@@ -466,14 +475,15 @@ returns how many messages were actually sent (or queued for sending).</p>
 sending each individual datagram until either the end of the list has been reached or the first error occurred.
 If at least one datagram has been sent successfully, this function never returns an error.</p>
 <p>If the input list is empty, the function returns <code>ok(0)</code>.</p>
-<p>The remote address option is required. To send a message to the &quot;connected&quot; peer,
-call <a href="#remote_address"><code>remote-address</code></a> to get their address.</p>
+<p>On &quot;connected&quot; sockets, the <a href="#remote_address"><code>remote-address</code></a> is optional.
+This is equivalent to <a href="#send"><code>send</code></a> in POSIX or <code>sendmsg</code> without a remote address.</p>
 <h1>Typical errors</h1>
 <ul>
 <li><code>address-family-mismatch</code>: The <a href="#remote_address"><code>remote-address</code></a> has the wrong address family. (EAFNOSUPPORT)</li>
 <li><code>invalid-remote-address</code>:  The IP address in <a href="#remote_address"><code>remote-address</code></a> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-remote-address</code>:  The port in <a href="#remote_address"><code>remote-address</code></a> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
-<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and the <code>datagram.remote-address</code> does not match the address passed to <code>connect</code>. (EISCONN)</li>
+<li><code>already-connected</code>:       The socket is in &quot;connected&quot; mode and <a href="#remote_address"><code>remote-address</code></a> is <code>some</code> value that does not match the address passed to <code>connect</code>. (EISCONN)</li>
+<li><code>not-connected</code>:           The socket is not &quot;connected&quot; and no value for <a href="#remote_address"><code>remote-address</code></a> was provided. (EDESTADDRREQ)</li>
 <li><code>not-bound</code>:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.</li>
 <li><code>remote-unreachable</code>:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)</li>
 <li><code>datagram-too-large</code>:      The datagram is too large. (EMSGSIZE)</li>

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -9,8 +9,16 @@ interface udp {
 
 
 	record datagram {
-		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
-		remote-address: ip-socket-address,
+		/// The payload.
+		/// 
+		/// Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+		data: list<u8>,
+
+		/// The peer address.
+		/// 
+		/// Equivalent to the `src_addr` out parameter of `recvfrom` and the `msghdr::msg_name` out parameter of `recvmsg`.
+		/// Equivalent to the `dest_addr` parameter of `sendto` and the `msghdr::msg_name` parameter of `sendmsg`.
+		remote-address: option<ip-socket-address>,
 
 		/// Possible future additions:
 		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
@@ -117,14 +125,15 @@ interface udp {
 	/// 
 	/// If the input list is empty, the function returns `ok(0)`.
 	/// 
-	/// The remote address option is required. To send a message to the "connected" peer,
-	/// call `remote-address` to get their address.
+	/// On "connected" sockets, the `remote-address` is optional.
+	/// This is equivalent to `send` in POSIX or `sendmsg` without a remote address.
 	/// 
 	/// # Typical errors
 	/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 	/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 	/// - `invalid-remote-address`:  The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-	/// - `already-connected`:       The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+	/// - `already-connected`:       The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `connect`. (EISCONN)
+	/// - `not-connected`:           The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
 	/// - `not-bound`:               The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
 	/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 	/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)


### PR DESCRIPTION
by making datagram::remote-address optional.

Fixes #49