### PR TITLE
UDP & TCP: Sticky IP options (IP_TOS, IPV6_TCLASS, IP_DONTFRAG & IPV6_DONTFRAG)

### DIFF
--- a/Posix-compatibility.md
+++ b/Posix-compatibility.md
@@ -159,16 +159,16 @@ Columns:
 | IPV6_UNICAST_HOPS               | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
 | IP_RECVTTL                      | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | IPV6_RECVHOPLIMIT               | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
-| IP_TOS                          | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | |
-| IPV6_TCLASS                     | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | |
+| IP_TOS                          | ✅       | ❌     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | [`tcp::(set-)traffic-class`](tcp)<br/>[`udp::(set-)traffic-class`](udp) |
+| IPV6_TCLASS                     | ✅       | ❌     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | [`tcp::(set-)traffic-class`](tcp)<br/>[`udp::(set-)traffic-class`](udp) |
 | IP_RECVTOS                      | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | |
 | IPV6_RECVTCLASS                 | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ✅    | ❌   | |
 | IP_RECVPKTINFO                  | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IP_PKTINFO on Linux & Windows, IP_RECVDSTADDR+IP_RECVIF on MacOS & FreeBSD. |
 | IPV6_RECVPKTINFO                | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IPV6_PKTINFO on Windows. |
-| IP_DONTFRAG                     | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | IP_DONTFRAGMENT on Windows, implementable using IP_MTU_DISCOVER on Linux. |
-| IPV6_DONTFRAG                   | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | |
-| IP_MTU_DISCOVER                 | ❔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | |
-| IPV6_MTU_DISCOVER               | ❔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | |
+| IP_DONTFRAG                     | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | [`udp::(set-)dont-fragment`](udp) <br/><br/> IP_DONTFRAGMENT on Windows, implementable using IP_MTU_DISCOVER on Linux. |
+| IPV6_DONTFRAG                   | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ✅      | ✅    | ❌    | ✅    | ❌   | [`udp::(set-)dont-fragment`](udp) |
+| IP_MTU_DISCOVER                 | ❔*      | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | Only the IP_PMTUDISC_DO behaviour is supported as part of IP_DONTFRAG. |
+| IPV6_MTU_DISCOVER               | ❔*      | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ❌    | ❌   | ❌      | ❌  | ✅      | ✅    | ✅    | ✅    | ❌   | Only the IP_PMTUDISC_DO behaviour is supported as part of IPV6_DONTFRAG. |
 | SO_RCVBUF                       | ✅       | ✅     | ✅    | ❌      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ❌    | ✅    | ❌   | [`tcp::(set-)receive-buffer-size`](tcp)<br/>[`udp::(set-)receive-buffer-size`](udp) |
 | SO_SNDBUF                       | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ❌      | ✅    | ✅    | ❌    | ❌   | [`tcp::(set-)send-buffer-size`](tcp)<br/>[`udp::(set-)send-buffer-size`](udp) |
 | SO_RCVLOWAT                     | ❔       | ✅     | ✅    | ❌      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |

--- a/Posix-compatibility.md
+++ b/Posix-compatibility.md
@@ -155,8 +155,8 @@ Columns:
 | IPV6_V6ONLY                     | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ✅  | ✅      | ❌    | ✅    | ✅    | ✅   | [`tcp::(set-)ipv6-only`](tcp)<br/>[`udp::(set-)ipv6-only`](udp) |
 | IP_HDRINCL                      | ⛔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Out of scope. Raw sockets only. |
 | IPV6_HDRINCL                    | ⛔       | ❌     | ✅    | ✅      | ❌     | ❌      | ❌    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | Out of scope. Raw sockets only. |
-| IP_TTL                          | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)unicast-hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
-| IPV6_UNICAST_HOPS               | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)unicast-hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
+| IP_TTL                          | ✅       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ✅   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
+| IPV6_UNICAST_HOPS               | ✅       | ✅     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ✅      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | [`tcp::(set-)hop-limit`](tcp)<br/>[`udp::(set-)unicast-hop-limit`](udp) |
 | IP_RECVTTL                      | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | IPV6_RECVHOPLIMIT               | ❔       | ❌     | ✅    | ❌      | ✅     | ✅      | ❌    | ❌    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ❌   | |
 | IP_TOS                          | ❔       | ❌     | ✅    | ✅      | ✅     | ✅      | ✅    | ✅    | ❌   | ❌      | ❌  | ❌      | ❌    | ❌    | ❌    | ✅   | |

--- a/example-world.md
+++ b/example-world.md
@@ -604,6 +604,62 @@ call <a href="#remote_address"><code>remote-address</code></a> to get their addr
 <ul>
 <li><a name="set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
+<h4><a name="traffic_class"><code>traffic-class: func</code></a></h4>
+<p>Equivalent to the IP_TOS &amp; IPV6_TCLASS socket options.</p>
+<p>The value is typically composed of the DSCP (6 high bits) + ECN (2 low bits).</p>
+<h1>Implementors note</h1>
+<p>Windows does not support this.</p>
+<h1>Typical errors</h1>
+<ul>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h5>Params</h5>
+<ul>
+<li><a name="traffic_class.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="traffic_class.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="set_traffic_class"><code>set-traffic-class: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="set_traffic_class.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="set_traffic_class.value"><code>value</code></a>: <code>u8</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="set_traffic_class.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="dont_fragment"><code>dont-fragment: func</code></a></h4>
+<p>Equivalent to the IP_DONTFRAG &amp; IPV6_DONTFRAG socket options.</p>
+<h1>Implementors note</h1>
+<ul>
+<li>IP_DONTFRAGMENT on Windows</li>
+<li>Linux has no direct equivalent, but the same effect can be reached by setting IP_MTU_DISCOVER to IP_PMTUDISC_DO.</li>
+</ul>
+<h1>Typical errors</h1>
+<ul>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h5>Params</h5>
+<ul>
+<li><a name="dont_fragment.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="dont_fragment.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="set_dont_fragment"><code>set-dont-fragment: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="set_dont_fragment.this"><code>this</code></a>: <a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a></li>
+<li><a name="set_dont_fragment.value"><code>value</code></a>: <code>bool</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="set_dont_fragment.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
 <h4><a name="receive_buffer_size"><code>receive-buffer-size: func</code></a></h4>
 <p>The kernel buffer space reserved for sends/receives on this socket.</p>
 <p>Note #1: an implementation may choose to cap or round the buffer size when setting the value.
@@ -1356,6 +1412,35 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="set_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="traffic_class"><code>traffic-class: func</code></a></h4>
+<p>Equivalent to the IP_TOS &amp; IPV6_TCLASS socket options.</p>
+<p>The value is typically composed of the DSCP (6 high bits) + ECN (2 low bits).</p>
+<h1>Implementors note</h1>
+<p>Windows does not support this.</p>
+<h1>Typical errors</h1>
+<ul>
+<li><code>already-connected</code>:    (set) The socket is already in the Connection state.</li>
+<li><code>already-listening</code>:    (set) The socket is already in the Listener state.</li>
+<li><code>concurrency-conflict</code>: (set) A <code>bind</code>, <code>connect</code> or <code>listen</code> operation is already in progress. (EALREADY)</li>
+</ul>
+<h5>Params</h5>
+<ul>
+<li><a name="traffic_class.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="traffic_class.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+</ul>
+<h4><a name="set_traffic_class"><code>set-traffic-class: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="set_traffic_class.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="set_traffic_class.value"><code>value</code></a>: <code>u8</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="set_traffic_class.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="receive_buffer_size"><code>receive-buffer-size: func</code></a></h4>
 <p>The kernel buffer space reserved for sends/receives on this socket.</p>

--- a/example-world.md
+++ b/example-world.md
@@ -1331,7 +1331,7 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 <ul>
 <li><a name="set_no_delay.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="unicast_hop_limit"><code>unicast-hop-limit: func</code></a></h4>
+<h4><a name="hop_limit"><code>hop-limit: func</code></a></h4>
 <p>Equivalent to the IP_TTL &amp; IPV6_UNICAST_HOPS socket options.</p>
 <h1>Typical errors</h1>
 <ul>
@@ -1341,21 +1341,21 @@ a pair of streams that can be used to read &amp; write to the connection.</p>
 </ul>
 <h5>Params</h5>
 <ul>
-<li><a name="unicast_hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="unicast_hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="hop_limit.0"></a> result&lt;<code>u8</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
-<h4><a name="set_unicast_hop_limit"><code>set-unicast-hop-limit: func</code></a></h4>
+<h4><a name="set_hop_limit"><code>set-hop-limit: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
-<li><a name="set_unicast_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
+<li><a name="set_hop_limit.this"><code>this</code></a>: <a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a></li>
+<li><a name="set_hop_limit.value"><code>value</code></a>: <code>u8</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="set_unicast_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
+<li><a name="set_hop_limit.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="receive_buffer_size"><code>receive-buffer-size: func</code></a></h4>
 <p>The kernel buffer space reserved for sends/receives on this socket.</p>

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -198,8 +198,8 @@ interface tcp {
 	/// - `already-connected`:    (set) The socket is already in the Connection state.
 	/// - `already-listening`:    (set) The socket is already in the Listener state.
 	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-	unicast-hop-limit: func(this: tcp-socket) -> result<u8, error-code>
-	set-unicast-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
+	hop-limit: func(this: tcp-socket) -> result<u8, error-code>
+	set-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
 
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -201,6 +201,20 @@ interface tcp {
 	hop-limit: func(this: tcp-socket) -> result<u8, error-code>
 	set-hop-limit: func(this: tcp-socket, value: u8) -> result<_, error-code>
 
+	/// Equivalent to the IP_TOS & IPV6_TCLASS socket options.
+	/// 
+	/// The value is typically composed of the DSCP (6 high bits) + ECN (2 low bits).
+	/// 
+	/// # Implementors note
+	/// Windows does not support this.
+	/// 
+	/// # Typical errors
+	/// - `already-connected`:    (set) The socket is already in the Connection state.
+	/// - `already-listening`:    (set) The socket is already in the Listener state.
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	traffic-class: func(this: tcp-socket) -> result<u8, error-code>
+	set-traffic-class: func(this: tcp-socket, value: u8) -> result<_, error-code>
+
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
 	/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -189,6 +189,29 @@ interface udp {
 	unicast-hop-limit: func(this: udp-socket) -> result<u8, error-code>
 	set-unicast-hop-limit: func(this: udp-socket, value: u8) -> result<_, error-code>
 
+	/// Equivalent to the IP_TOS & IPV6_TCLASS socket options.
+	/// 
+	/// The value is typically composed of the DSCP (6 high bits) + ECN (2 low bits).
+	/// 
+	/// # Implementors note
+	/// Windows does not support this.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	traffic-class: func(this: udp-socket) -> result<u8, error-code>
+	set-traffic-class: func(this: udp-socket, value: u8) -> result<_, error-code>
+
+	/// Equivalent to the IP_DONTFRAG & IPV6_DONTFRAG socket options.
+	/// 
+	/// # Implementors note
+	/// - IP_DONTFRAGMENT on Windows
+	/// - Linux has no direct equivalent, but the same effect can be reached by setting IP_MTU_DISCOVER to IP_PMTUDISC_DO.
+	/// 
+	/// # Typical errors
+	/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
+	dont-fragment: func(this: udp-socket) -> result<bool, error-code>
+	set-dont-fragment: func(this: udp-socket, value: bool) -> result<_, error-code>
+
 	/// The kernel buffer space reserved for sends/receives on this socket.
 	/// 
 	/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.


### PR DESCRIPTION
- Remove redundant `unicast` prefix from `tcp::(set-)unicast-hop-limit`. TCP is always unicast.
- Add IP_TOS, IPV6_TCLASS, IP_DONTFRAG & IPV6_DONTFRAG socket options.