### PR TITLE
Document SO_REUSEADDR to be the default for TCP `bind`

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -1190,6 +1190,10 @@ implicitly bind the socket.</p>
 <li><code>not-in-progress</code>:           A <code>bind</code> operation is not in progress.</li>
 <li><code>would-block</code>:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)</li>
 </ul>
+<h1>Implementors note</h1>
+<p>When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+state of a recently closed socket on the same local address (i.e. the SO_REUSEADDR socket
+option should be set implicitly on platforms that require it).</p>
 <h1>References</h1>
 <ul>
 <li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</a></li>

--- a/imports.md
+++ b/imports.md
@@ -1192,8 +1192,9 @@ implicitly bind the socket.</p>
 </ul>
 <h1>Implementors note</h1>
 <p>When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
-state of a recently closed socket on the same local address (i.e. the SO_REUSEADDR socket
-option should be set implicitly on platforms that require it).</p>
+state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR
+socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+and SO_REUSEADDR performs something different entirely.</p>
 <h1>References</h1>
 <ul>
 <li><a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html">https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html</a></li>

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -42,6 +42,11 @@ interface tcp {
         /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
         /// - `not-in-progress`:           A `bind` operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        /// 
+        /// # Implementors note
+        /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+        /// state of a recently closed socket on the same local address (i.e. the SO_REUSEADDR socket
+        /// option should be set implicitly on platforms that require it).
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -45,8 +45,9 @@ interface tcp {
         /// 
         /// # Implementors note
         /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
-        /// state of a recently closed socket on the same local address (i.e. the SO_REUSEADDR socket
-        /// option should be set implicitly on platforms that require it).
+        /// state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR 
+        /// socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+        /// and SO_REUSEADDR performs something different entirely.
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>


### PR DESCRIPTION
For TCP sockets specifically, this is a reasonable default for WASI to recommend:
- For the vast majority of cases, this is "what you want"
- On Windows this is the default behavior and can't be opted out of. In other words: every existing cross-platform application already has to deal with this behavior.
- This makes it easier to implement wasi-sockets on top of standard libraries that set SO_REUSEADDR by default too. Examples:
  - https://github.com/rust-lang/rust/blob/e51e98dde6a60637b6a71b8105245b629ac3fe77/library/std/src/sys_common/net.rs#L408
  - https://github.com/libuv/libuv/blob/v1.x/src/unix/tcp.c#L167
  - https://github.com/dotnet/runtime/blob/23e5d5410ed3e8bc9ab61b3685e1d3a06bdba701/src/native/libs/System.Native/pal_networking.c#L1566
  - https://github.com/golang/go/blob/master/src/net/sockopt_linux.go#L28
- This does not preclude us from adding an advanced option in the future to opt-out of this.

---

This is the behavior as implemented by [Wasmtime](https://github.com/bytecodealliance/wasmtime/blob/8573214213c05f970f29a998016f190c3766a789/crates/wasi/src/preview2/host/tcp.rs#L57) and [JCO](https://github.com/libuv/libuv/blob/v1.x/src/unix/tcp.c#L167).