### PR TITLE
Make `ipv6-only` the default and remove the ability to configure it.

### DIFF
--- a/Posix-compatibility.md
+++ b/Posix-compatibility.md
@@ -139,6 +139,7 @@ Additionally, most columns have been populated semi-automatically by grepping th
 
 Legend:
 - ✅ = Included in proposal.
+- ⚠️ = Partially supported.
 - ⛔ = Consciously decided _not_ to include in WASI. See notes for explanation.
 - ❔ = Not included (yet), for no particular reason.
 
@@ -147,7 +148,6 @@ Legend:
 |----| ---------------------------------|-----------------------------------------|---------------------|
 | ✅ | SO_DOMAIN <br/><sub>SO_PROTOCOL_INFO on Windows</sub> | [`tcp-socket::address-family`][tcp]<br/>[`udp-socket::address-family`][udp] | linux, windows, freebsd, .net |
 | ✅ | SO_ACCEPTCONN                   | [`tcp-socket::is-listening`][tcp]                                                                 | posix, linux, windows, macos, freebsd, .net |
-| ✅ | IPV6_V6ONLY                     | [`tcp-socket::(set-)ipv6-only`][tcp]<br/>[`udp-socket::(set-)ipv6-only`][udp]                     | posix, linux, windows, macos, freebsd, jvm, .net, libuv, go, openssl, curl, msquic, exim |
 | ✅ | IP_TTL                          | [`tcp-socket::(set-)hop-limit`][tcp]<br/>[`udp-socket::(set-)unicast-hop-limit`][udp]             | linux, windows, macos, freebsd, jvm, .net, rust, libuv |
 | ✅ | IPV6_UNICAST_HOPS               | [`tcp-socket::(set-)hop-limit`][tcp]<br/>[`udp-socket::(set-)unicast-hop-limit`][udp]             | posix, linux, windows, macos, freebsd, jvm, .net, libuv |
 | ✅ | SO_RCVBUF                       | [`tcp-socket::(set-)receive-buffer-size`][tcp]<br/>[`udp-socket::(set-)receive-buffer-size`][udp] | posix, linux, windows, macos, freebsd, jvm, .net, libuv, go, nginx, msquic |
@@ -157,6 +157,7 @@ Legend:
 | ✅ | TCP_KEEPINTVL                   | [`tcp-socket::(set-)keep-alive-interval`][tcp]                                                    | linux, windows, macos, freebsd, jvm, .net, libuv, go, nginx, curl |
 | ✅ | TCP_KEEPCNT                     | [`tcp-socket::(set-)keep-alive-count`][tcp]                                                       | linux, windows, macos, freebsd, jvm, .net, libuv, nginx |
 | ✅ | SO_REUSEADDR for TCP            | Enabled by default. See [`tcp-socket::bind`][tcp]                              | posix, linux, windows, macos, freebsd, jvm, .net, libuv, go, openssl, nginx, curl, exim |
+| ⚠️ | IPV6_V6ONLY                     | In WASI this always `true`. [#1][1]                                            | posix, linux, windows, macos, freebsd, jvm, .net, libuv, go, openssl, curl, msquic, exim |
 | ⛔ | SO_ERROR                        | Not necessary. WIT has (or will have) native support for asynchronous results. | posix, linux, windows, macos, freebsd, jvm, .net, rust, libuv, go, openssl, nginx, curl, msquic |
 | ⛔ | SO_TYPE                         | Can be inferred from the socket resource type.                                 | posix, linux, windows, macos, freebsd, jvm, .net, go, openssl, nginx, curl, exim |
 | ⛔ | SO_PROTOCOL <br/><sub>SO_PROTOCOL_INFO on Windows</sub> | Can be inferred from the socket resource type.         | linux, windows, freebsd, .net, exim |
@@ -586,6 +587,7 @@ Legend:
 | ❔ | TCP_USE_CMP_ACKS                |                                          | freebsd |
 | ❔ | TCP_USER_LOG                    |                                          | freebsd |
 
+[1]: https://github.com/WebAssembly/wasi-sockets/issues/1
 [17]: https://github.com/WebAssembly/wasi-sockets/issues/17
 [34]: https://github.com/WebAssembly/wasi-sockets/issues/34
 [73]: https://github.com/WebAssembly/wasi-sockets/issues/73

--- a/imports.md
+++ b/imports.md
@@ -403,7 +403,6 @@ if (remote_address is Some) {
 <h1>Typical errors</h1>
 <ul>
 <li><code>invalid-argument</code>:          The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-argument</code>:          <code>remote-address</code> is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)</li>
 <li><code>invalid-argument</code>:          The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-argument</code>:          The port in <code>remote-address</code> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-state</code>:             The socket is not bound.</li>
@@ -485,33 +484,6 @@ stored in the object pointed to by <code>address</code> is unspecified.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="method_udp_socket.address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
-</ul>
-<h4><a name="method_udp_socket.ipv6_only"><code>[method]udp-socket.ipv6-only: func</code></a></h4>
-<p>Whether IPv4 compatibility (dual-stack) mode is disabled or not.</p>
-<p>Equivalent to the IPV6_V6ONLY socket option.</p>
-<h1>Typical errors</h1>
-<ul>
-<li><code>not-supported</code>:        (get/set) <code>this</code> socket is an IPv4 socket.</li>
-<li><code>invalid-state</code>:        (set) The socket is already bound.</li>
-<li><code>not-supported</code>:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)</li>
-</ul>
-<h5>Params</h5>
-<ul>
-<li><a name="method_udp_socket.ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="method_udp_socket.ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="method_udp_socket.set_ipv6_only"><code>[method]udp-socket.set-ipv6-only: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="method_udp_socket.set_ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#udp_socket"><a href="#udp_socket"><code>udp-socket</code></a></a>&gt;</li>
-<li><a name="method_udp_socket.set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="method_udp_socket.set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_udp_socket.unicast_hop_limit"><code>[method]udp-socket.unicast-hop-limit: func</code></a></h4>
 <p>Equivalent to the IP_TTL &amp; IPV6_UNICAST_HOPS socket options.</p>
@@ -675,7 +647,6 @@ either <code>check-send</code> was not called or <code>datagrams</code> contains
 <h1>Typical errors</h1>
 <ul>
 <li><code>invalid-argument</code>:        The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
-<li><code>invalid-argument</code>:        <code>remote-address</code> is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)</li>
 <li><code>invalid-argument</code>:        The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-argument</code>:        The port in <code>remote-address</code> is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)</li>
 <li><code>invalid-argument</code>:        The socket is in &quot;connected&quot; mode and <code>remote-address</code> is <code>some</code> value that does not match the address passed to <code>stream</code>. (EISCONN)</li>
@@ -735,7 +706,8 @@ It's planned to be removed when <code>future</code> is natively supported in Pre
 <h3>Functions</h3>
 <h4><a name="create_udp_socket"><code>create-udp-socket: func</code></a></h4>
 <p>Create a new UDP socket.</p>
-<p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)</code> in POSIX.</p>
+<p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)</code> in POSIX.
+On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.</p>
 <p>This function does not require a network capability handle. This is considered to be safe because
 at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <code>bind</code> is called,
 the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>
@@ -1230,7 +1202,7 @@ implicitly bind the socket.</p>
 <ul>
 <li><code>invalid-argument</code>:          The <code>local-address</code> has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)</li>
 <li><code>invalid-argument</code>:          <code>local-address</code> is not a unicast address. (EINVAL)</li>
-<li><code>invalid-argument</code>:          <code>local-address</code> is an IPv4-mapped IPv6 address, but the socket has <code>ipv6-only</code> enabled. (EINVAL)</li>
+<li><code>invalid-argument</code>:          <code>local-address</code> is an IPv4-mapped IPv6 address. (EINVAL)</li>
 <li><code>invalid-state</code>:             The socket is already bound. (EINVAL)</li>
 </ul>
 <h1>Typical <code>finish</code> errors</h1>
@@ -1294,8 +1266,7 @@ Besides <code>drop</code>, any method after such a failure may return an error.<
 <ul>
 <li><code>invalid-argument</code>:          The <code>remote-address</code> has the wrong address family. (EAFNOSUPPORT)</li>
 <li><code>invalid-argument</code>:          <code>remote-address</code> is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)</li>
-<li><code>invalid-argument</code>:          <code>remote-address</code> is an IPv4-mapped IPv6 address, but the socket has <code>ipv6-only</code> enabled. (EINVAL, EADDRNOTAVAIL on Illumos)</li>
-<li><code>invalid-argument</code>:          <code>remote-address</code> is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)</li>
+<li><code>invalid-argument</code>:          <code>remote-address</code> is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)</li>
 <li><code>invalid-argument</code>:          The IP address in <code>remote-address</code> is set to INADDR_ANY (<code>0.0.0.0</code> / <code>::</code>). (EADDRNOTAVAIL on Windows)</li>
 <li><code>invalid-argument</code>:          The port in <code>remote-address</code> is set to 0. (EADDRNOTAVAIL on Windows)</li>
 <li><code>invalid-argument</code>:          The socket is already attached to a different network. The <a href="#network"><code>network</code></a> passed to <code>connect</code> must be identical to the one passed to <code>bind</code>.</li>
@@ -1388,7 +1359,6 @@ Besides <code>drop</code>, any method after such a failure may return an error.<
 <p>The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:</p>
 <ul>
 <li><code>address-family</code></li>
-<li><code>ipv6-only</code></li>
 <li><code>keep-alive-enabled</code></li>
 <li><code>keep-alive-idle-time</code></li>
 <li><code>keep-alive-interval</code></li>
@@ -1490,33 +1460,6 @@ stored in the object pointed to by <code>address</code> is unspecified.</p>
 <h5>Return values</h5>
 <ul>
 <li><a name="method_tcp_socket.address_family.0"></a> <a href="#ip_address_family"><a href="#ip_address_family"><code>ip-address-family</code></a></a></li>
-</ul>
-<h4><a name="method_tcp_socket.ipv6_only"><code>[method]tcp-socket.ipv6-only: func</code></a></h4>
-<p>Whether IPv4 compatibility (dual-stack) mode is disabled or not.</p>
-<p>Equivalent to the IPV6_V6ONLY socket option.</p>
-<h1>Typical errors</h1>
-<ul>
-<li><code>invalid-state</code>:        (set) The socket is already bound.</li>
-<li><code>not-supported</code>:        (get/set) <code>this</code> socket is an IPv4 socket.</li>
-<li><code>not-supported</code>:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)</li>
-</ul>
-<h5>Params</h5>
-<ul>
-<li><a name="method_tcp_socket.ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="method_tcp_socket.ipv6_only.0"></a> result&lt;<code>bool</code>, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
-</ul>
-<h4><a name="method_tcp_socket.set_ipv6_only"><code>[method]tcp-socket.set-ipv6-only: func</code></a></h4>
-<h5>Params</h5>
-<ul>
-<li><a name="method_tcp_socket.set_ipv6_only.self"><code>self</code></a>: borrow&lt;<a href="#tcp_socket"><a href="#tcp_socket"><code>tcp-socket</code></a></a>&gt;</li>
-<li><a name="method_tcp_socket.set_ipv6_only.value"><code>value</code></a>: <code>bool</code></li>
-</ul>
-<h5>Return values</h5>
-<ul>
-<li><a name="method_tcp_socket.set_ipv6_only.0"></a> result&lt;_, <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a>&gt;</li>
 </ul>
 <h4><a name="method_tcp_socket.set_listen_backlog_size"><code>[method]tcp-socket.set-listen-backlog-size: func</code></a></h4>
 <p>Hints the desired listen queue size. Implementations are free to ignore this.</p>
@@ -1787,7 +1730,8 @@ operations on the <a href="#output_stream"><code>output-stream</code></a> associ
 <h3>Functions</h3>
 <h4><a name="create_tcp_socket"><code>create-tcp-socket: func</code></a></h4>
 <p>Create a new TCP socket.</p>
-<p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)</code> in POSIX.</p>
+<p>Similar to <code>socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)</code> in POSIX.
+On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.</p>
 <p>This function does not require a network capability handle. This is considered to be safe because
 at time of creation, the socket is not bound to any <a href="#network"><code>network</code></a> yet. Up to the moment <code>bind</code>/<code>listen</code>/<code>connect</code>
 is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.</p>

--- a/wit/tcp-create-socket.wit
+++ b/wit/tcp-create-socket.wit
@@ -6,6 +6,7 @@ interface tcp-create-socket {
     /// Create a new TCP socket.
     ///
     /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
     ///
     /// This function does not require a network capability handle. This is considered to be safe because
     /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`

--- a/wit/tcp.wit
+++ b/wit/tcp.wit
@@ -33,7 +33,7 @@ interface tcp {
         /// # Typical `start` errors
         /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
         /// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
-        /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
+        /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
         /// - `invalid-state`:             The socket is already bound. (EINVAL)
         ///
         /// # Typical `finish` errors
@@ -75,8 +75,7 @@ interface tcp {
         /// # Typical `start` errors
         /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
         /// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
-        /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
-        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
         /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
         /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
         /// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
@@ -131,7 +130,6 @@ interface tcp {
         ///
         /// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
         /// - `address-family`
-        /// - `ipv6-only`
         /// - `keep-alive-enabled`
         /// - `keep-alive-idle-time`
         /// - `keep-alive-interval`
@@ -195,17 +193,6 @@ interface tcp {
         ///
         /// Equivalent to the SO_DOMAIN socket option.
         address-family: func() -> ip-address-family;
-
-        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-        ///
-        /// Equivalent to the IPV6_V6ONLY socket option.
-        ///
-        /// # Typical errors
-        /// - `invalid-state`:        (set) The socket is already bound.
-        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-        ipv6-only: func() -> result<bool, error-code>;
-        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
         /// Hints the desired listen queue size. Implementations are free to ignore this.
         ///

--- a/wit/udp-create-socket.wit
+++ b/wit/udp-create-socket.wit
@@ -6,6 +6,7 @@ interface udp-create-socket {
     /// Create a new UDP socket.
     ///
     /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
     ///
     /// This function does not require a network capability handle. This is considered to be safe because
     /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind` is called,

--- a/wit/udp.wit
+++ b/wit/udp.wit
@@ -92,7 +92,6 @@ interface udp {
         /// 
         /// # Typical errors
         /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
         /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-state`:             The socket is not bound.
@@ -141,17 +140,6 @@ interface udp {
         ///
         /// Equivalent to the SO_DOMAIN socket option.
         address-family: func() -> ip-address-family;
-
-        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-        ///
-        /// Equivalent to the IPV6_V6ONLY socket option.
-        ///
-        /// # Typical errors
-        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-        /// - `invalid-state`:        (set) The socket is already bound.
-        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-        ipv6-only: func() -> result<bool, error-code>;
-        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
         ///
@@ -248,7 +236,6 @@ interface udp {
         ///
         /// # Typical errors
         /// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-        /// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
         /// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `stream`. (EISCONN)


### PR DESCRIPTION
Currently, the spec doesn't mention anything about the default value of `ipv6-only`. This PR changes that to be `true`, because that's universally supported.

This requires a change in wasmtime.
JCO should be good to go as [libuv does this by default](https://github.com/libuv/libuv/blob/3b6a1a14caeeeaf5510f2939a8e28ed9ba0ad968/src/unix/tcp.c#L172).

---

Additionally, this PR removes the ability to enable dual-stack sockets (`ipv6-only==false`) altogether as the OS-support is questionable: 
- Linux: Supported.
- Windows: Supported, but disabled by default.
- MacOS: Buggy. Ancillary messages for IPv4 traffic on IPv6 UDP sockets don't appear to work.
- *BSD: Not supported

This removal does not preclude us from adding an advanced option in the future to opt back in to this.