### PR TITLE
Add `network-error-code`

### DIFF
--- a/wit/network.wit
+++ b/wit/network.wit
@@ -1,5 +1,8 @@
 @since(version = 0.2.0)
 interface network {
+    @unstable(feature = network-error-code)
+    use wasi:io/error@0.2.1.{error};
+
     /// An opaque resource that represents access to (a subset of) the network.
     /// This enables context-based security for networking.
     /// There is no need for this to map 1:1 to a physical network interface.
@@ -104,6 +107,19 @@ interface network {
         /// A permanent failure in name resolution occurred.
         permanent-resolver-failure,
     }
+
+    /// Attempts to extract a network-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// network-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are network-related errors.
+    @unstable(feature = network-error-code)
+    network-error-code: func(err: borrow<error>) -> option<error-code>;
 
     @since(version = 0.2.0)
     enum ip-address-family {


### PR DESCRIPTION
Add function to downcast a stream error to a network-related error.
Similar to the existing `filesystem-error-code` and `http-error-code` functions.

Wasmtime implementation is ready at: https://github.com/badeend/wasmtime/commit/7411bf12794a62e4729696e256f465e89f0c952b