### PR TITLE
feat(0.3): make `accept` fallible

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -286,7 +286,7 @@ interface types {
         /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
         @since(version = 0.3.0)
-        listen: func() -> result<stream<tcp-socket>, error-code>;
+        listen: func() -> result<stream<result<tcp-socket, error-code>>, error-code>;
 
         /// Transmit data to peer.
         ///


### PR DESCRIPTION
`accept` is fallible, however there is currently no way to report the error to the user from the stream.

Change the stream element type to `result<tcp-stream, error-code>` to account for that

Ref https://www.man7.org/linux/man-pages/man2/accept.2.html
Ref https://github.com/bytecodealliance/wasip3-prototyping/blob/7dbc8a9fd6a2348e772a32382c3e29c88cad397e/crates/wasi/src/p3/sockets/host/types/tcp.rs#L195-L199

Ref https://github.com/bytecodealliance/wasip3-prototyping/pull/1