### PR TITLE
fix(wasip3): allow `send` on unbound UDP sockets

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -610,7 +610,6 @@ interface types {
         /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `connect`. (EISCONN)
         /// - `invalid-argument`:        The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
-        /// - `invalid-state`:           The socket has not been bound yet.
         /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
         /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
         /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)


### PR DESCRIPTION
Most other `udp-socket` methods (e.g. connect) rely on implicit binding of the socket, however `send` currently requires the socket to be bound, which is inconsistent

See https://github.com/bytecodealliance/wasip3-prototyping/pull/33 for an implementation