### PR TITLE
refactor(p3): clarify `tcp-socket.receive` semantics

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -328,7 +328,7 @@ interface types {
         /// were closed abnormally.
         ///
         /// If the caller is not expecting to receive any data from the peer,
-        /// they may cancel the receive task. Any data still in the receive queue
+        /// they may drop the stream. Any data still in the receive queue
         /// will be discarded. This is equivalent to calling `shutdown(SHUT_RD)`
         /// in POSIX.
         ///


### PR DESCRIPTION
- ~Futures can resolve to "no value" - use that property to simplify the signature and simply do not resolve to a result on success. As a side effect, this allows host implementations to fearlessly drop the tasks handling I/O without having to send a successful result~
- Clarify the semantics regarding shutdown - dropping the stream causes a `shutdown` in the host.

cc @alexcrichton @dicej