### PR TITLE
chore: mark async functions as such

### DIFF
--- a/wit-0.3.0-draft/ip-name-lookup.wit
+++ b/wit-0.3.0-draft/ip-name-lookup.wit
@@ -58,5 +58,5 @@ interface ip-name-lookup {
     /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
     /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
     @since(version = 0.3.0)
-    resolve-addresses: func(name: string) -> result<list<ip-address>, error-code>;
+    resolve-addresses: async func(name: string) -> result<list<ip-address>, error-code>;
 }

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -219,7 +219,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
         /// - <https://man.freebsd.org/cgi/man.cgi?connect>
         @since(version = 0.3.0)
-        connect: func(remote-address: ip-socket-address) -> result<_, error-code>;
+        connect: async func(remote-address: ip-socket-address) -> result<_, error-code>;
 
         /// Start listening return a stream of new inbound connections.
         ///
@@ -309,7 +309,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
         @since(version = 0.3.0)
-        send: func(data: stream<u8>) -> result<_, error-code>;
+        send: async func(data: stream<u8>) -> result<_, error-code>;
 
         /// Read data from peer.
         ///
@@ -624,7 +624,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
         @since(version = 0.3.0)
-        send: func(data: list<u8>, remote-address: option<ip-socket-address>) -> result<_, error-code>;
+        send: async func(data: list<u8>, remote-address: option<ip-socket-address>) -> result<_, error-code>;
 
         /// Receive a message on the socket.
         ///
@@ -650,7 +650,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/mswsock/nc-mswsock-lpfn_wsarecvmsg>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
         @since(version = 0.3.0)
-        receive: func() -> result<tuple<list<u8>, ip-socket-address>, error-code>;
+        receive: async func() -> result<tuple<list<u8>, ip-socket-address>, error-code>;
 
         /// Get the current bound address.
         ///


### PR DESCRIPTION
Mark async functions as such.

This is mostly extracted from WIT modified in-tree in https://github.com/bytecodealliance/wasip3-prototyping/tree/9c837320498adb1f4bda9ad7bbb12769fcdd08b5/crates/wasi/src/p3/wit/deps/sockets