### PR TITLE
Change constructors to fallible static methods.

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -153,7 +153,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
         @since(version = 0.3.0)
-        new: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+        create: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 
         /// Bind the socket to the provided IP address and port.
         ///

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -512,7 +512,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
         @since(version = 0.3.0)
-        new: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+        create: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 
         /// Bind the socket to the provided IP address and port.
         ///

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -153,7 +153,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
         @since(version = 0.3.0)
-        constructor(address-family: ip-address-family);
+        new: static func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 
         /// Bind the socket to the provided IP address and port.
         ///
@@ -512,7 +512,7 @@ interface types {
         /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
         /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
         @since(version = 0.3.0)
-        constructor(address-family: ip-address-family);
+        new: static func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 
         /// Bind the socket to the provided IP address and port.
         ///


### PR DESCRIPTION
Socket creation may fail under certain conditions. WIT does not allow constructors to be fallible (yet). So this is changing socket creation to a static fallible method. Freeing up the resource's `constructor` for if/when fallible constructors have been implemented.

Relates to #128 