### PR TITLE
ci: must use same oci URI package as 0.2

### DIFF
--- a/.github/workflows/publish-0.3.yml
+++ b/.github/workflows/publish-0.3.yml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/webassembly/wasi/sockets-0.3.0
+          images: ghcr.io/webassembly/wasi/sockets
           tags: |
             type=semver,pattern={{version}}
 
@@ -59,7 +59,7 @@ jobs:
         id: publish
         uses: bytecodealliance/wkg-github-action@v5
         with:
-            oci-reference-without-tag: "ghcr.io/webassembly/wasi/sockets-0.3.0"
+            oci-reference-without-tag: "ghcr.io/webassembly/wasi/sockets"
             file: "${{ github.event.repository.name }}-0.3.0.wasm"
             description: "A WASI API for reading the current time and measuring elapsed time (0.3.0 version)."
             source: 'https://github.com/webassembly/wasi'
@@ -69,4 +69,4 @@ jobs:
 
       # Sign the output component
       - name: Sign the wasm component
-        run: cosign sign --yes ghcr.io/webassembly/wasi/sockets-0.3.0@${{ steps.publish.outputs.digest }}
+        run: cosign sign --yes ghcr.io/webassembly/wasi/sockets@${{ steps.publish.outputs.digest }}


### PR DESCRIPTION
Limited by wkg registry discovery for downstream wkg build
