### PR TITLE
use new clocks/types.{duration} instead of clocks/monotonic

### DIFF
--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -1,7 +1,7 @@
 @since(version = 0.3.0-rc-2025-09-16)
 interface types {
     @since(version = 0.3.0-rc-2025-09-16)
-    use wasi:clocks/monotonic-clock@0.3.0-rc-2025-09-16.{duration};
+    use wasi:clocks/types@0.3.0-rc-2025-09-16.{duration};
 
     /// Error codes.
     ///


### PR DESCRIPTION
https://github.com/WebAssembly/wasi-clocks/pull/98 split the `duration` type out into its own file, which can be imported directly instead of needing to reach into the `monotonic` package. This is [already pulled in to the deps](https://github.com/WebAssembly/wasi-sockets/blob/bfff49c8d3bca166f53eec7a6a2d53a0adac549d/wit-0.3.0-draft/deps/clocks/types.wit) so should be usable here.